### PR TITLE
fix: Edit/Writeフックをプロジェクト内ファイルのみブロックに変更

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "branch=$(git branch --show-current 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo 'mainブランチでの編集は禁止です。featureブランチを作成してください。' >&2; exit 2; fi"
+            "command": "branch=$(git branch --show-current 2>/dev/null); file_path=$(echo \"$CLAUDE_TOOL_INPUT\" | jq -r '.file_path // empty'); if [ \"$branch\" = \"main\" ] && [ -n \"$file_path\" ] && echo \"$file_path\" | grep -q \"^$CLAUDE_PROJECT_DIR\"; then echo 'mainブランチでのプロジェクト内ファイル編集は禁止です。featureブランチを作成してください。' >&2; exit 2; fi"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Edit/Writeフックのmainブランチブロックをプロジェクト内ファイルのみに限定
- `/tmp/claude/` 等プロジェクト外ファイルへの書き込みを許可

## Test plan
- [ ] mainブランチでプロジェクト内ファイルの編集がブロックされること
- [ ] mainブランチでプロジェクト外ファイル（`/tmp/claude/` 等）の編集が許可されること
- [ ] featureブランチではプロジェクト内外とも編集可能なこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)
