### PR TITLE
feat: migrate web data fetching to API

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,68 @@
+[mcp_servers.playwright]
+command = "npx"
+args = ["-y", "@playwright/mcp@latest"]
+
+[mcp_servers.playwright.env]
+
+[mcp_servers.playwright.tools.browser_navigate]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_click]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_close]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_console_messages]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_drag]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_evaluate]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_file_upload]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_fill_form]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_handle_dialog]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_hover]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_navigate_back]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_network_requests]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_press_key]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_resize]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_run_code]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_select_option]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_snapshot]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_tabs]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_take_screenshot]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_type]
+approval_mode = "approve"
+
+[mcp_servers.playwright.tools.browser_wait_for]
+approval_mode = "approve"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,7 @@ pnpm lint         # Lint実行
 ## 開発フロー
 
 pencil.devでデザイン → AIエージェントがMCP経由でコード生成 → ロジック実装 → デザイン調整
+
+## MCP
+
+ブラウザでの動作確認やUI確認が必要な場合は、Playwright MCP を使って確認してよい。

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,6 +2,9 @@
   "name": "@todo-list/api",
   "version": "0.1.0",
   "private": true,
+  "exports": {
+    "./client": "./src/client.ts"
+  },
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc --noEmit",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,10 +1,31 @@
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import { categoriesRoute } from "./features/categories/route";
 import { tasksRoute } from "./features/tasks/route";
 import { timerSessionsRoute } from "./features/timer-sessions/route";
 import { workRecordsRoute } from "./features/work-records/route";
 
+function resolveCorsOrigin(origin: string) {
+  if (origin.startsWith("http://localhost:")) {
+    return origin;
+  }
+
+  if (origin.startsWith("http://127.0.0.1:")) {
+    return origin;
+  }
+
+  return "";
+}
+
 const app = new Hono()
+  .use(
+    "/*",
+    cors({
+      origin: resolveCorsOrigin,
+      allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+      allowHeaders: ["Content-Type"],
+    }),
+  )
   .route("/tasks", tasksRoute)
   .route("/categories", categoriesRoute)
   .route("/work-records", workRecordsRoute)

--- a/apps/api/src/client.ts
+++ b/apps/api/src/client.ts
@@ -1,0 +1,3 @@
+import type app from "./app";
+
+export type AppType = typeof app;

--- a/apps/api/src/features/categories/__tests__/categories.test.ts
+++ b/apps/api/src/features/categories/__tests__/categories.test.ts
@@ -41,6 +41,41 @@ describe("Categories API", () => {
       expect(body[0]).toHaveProperty("name");
       expect(body[0]).toHaveProperty("color");
     });
+
+    it("should include CORS headers for localhost origins", async () => {
+      const res = await app.request("/categories", {
+        headers: {
+          Origin: "http://localhost:3000",
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+        "http://localhost:3000",
+      );
+    });
+  });
+
+  describe("OPTIONS /categories", () => {
+    it("should handle preflight requests", async () => {
+      const res = await app.request("/categories", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "http://localhost:3000",
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers": "Content-Type",
+        },
+      });
+
+      expect(res.status).toBe(204);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+        "http://localhost:3000",
+      );
+      expect(res.headers.get("Access-Control-Allow-Methods")).toContain("POST");
+      expect(res.headers.get("Access-Control-Allow-Headers")).toContain(
+        "Content-Type",
+      );
+    });
   });
 
   describe("POST /categories", () => {

--- a/apps/api/src/features/tasks/service.ts
+++ b/apps/api/src/features/tasks/service.ts
@@ -16,7 +16,8 @@ export async function create(input: CreateTaskInput) {
       where: { id: input.categoryId },
       select: { id: true },
     });
-    if (!category) return { type: "category_not_found" } satisfies CreateTaskResult;
+    if (!category)
+      return { type: "category_not_found" } satisfies CreateTaskResult;
   }
 
   try {
@@ -54,7 +55,8 @@ export async function update(id: string, input: UpdateTaskInput) {
       where: { id: input.categoryId },
       select: { id: true },
     });
-    if (!category) return { type: "category_not_found" } satisfies UpdateTaskResult;
+    if (!category)
+      return { type: "category_not_found" } satisfies UpdateTaskResult;
   }
 
   try {

--- a/apps/api/src/features/timer-sessions/service.ts
+++ b/apps/api/src/features/timer-sessions/service.ts
@@ -24,7 +24,8 @@ export async function create(input: CreateTimerSessionInput) {
     where: { id: input.taskId },
     select: { id: true },
   });
-  if (!task) return { type: "task_not_found" } satisfies CreateTimerSessionResult;
+  if (!task)
+    return { type: "task_not_found" } satisfies CreateTimerSessionResult;
 
   try {
     const session = await prisma.timerSession.create({

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,9 +13,13 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.0.0",
+    "@todo-list/api": "workspace:*",
+    "@todo-list/schema": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "hono": "^4.7.0",
     "lucide-react": "^1.8.0",
     "next": "16.2.4",
     "radix-ui": "^1.4.3",

--- a/apps/web/src/app/calendar/page.tsx
+++ b/apps/web/src/app/calendar/page.tsx
@@ -1,5 +1,22 @@
+import {
+  getCategories,
+  getTasks,
+  getWorkRecords,
+} from "@/shared/lib/api/server";
 import { CalendarPage } from "@/views/calendar";
 
-export default function Page() {
-  return <CalendarPage />;
+export default async function Page() {
+  const [tasks, categories, workRecords] = await Promise.all([
+    getTasks(),
+    getCategories(),
+    getWorkRecords(),
+  ]);
+
+  return (
+    <CalendarPage
+      initialTasks={tasks}
+      initialCategories={categories}
+      initialWorkRecords={workRecords}
+    />
+  );
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import { getCurrentTimerSession } from "@/shared/lib/api/server";
+import { AppQueryProvider } from "@/shared/providers/query-provider";
 import { RecoveryDialogProvider } from "@/shared/ui/recovery-dialog-provider";
 import "./globals.css";
 
@@ -13,16 +15,22 @@ export const metadata: Metadata = {
   description: "副業タスク管理アプリ",
 };
 
-export default function RootLayout({
+export const dynamic = "force-dynamic";
+
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const initialTimerSession = await getCurrentTimerSession();
+
   return (
     <html lang="ja">
       <body className={`${inter.variable} font-sans antialiased`}>
-        {children}
-        <RecoveryDialogProvider />
+        <AppQueryProvider>
+          {children}
+          <RecoveryDialogProvider initialSession={initialTimerSession} />
+        </AppQueryProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,22 @@
+import {
+  getCategories,
+  getTasks,
+  getWorkRecords,
+} from "@/shared/lib/api/server";
 import { HomePage } from "@/views/home";
 
-export default function Page() {
-  return <HomePage />;
+export default async function Page() {
+  const [tasks, categories, workRecords] = await Promise.all([
+    getTasks(),
+    getCategories(),
+    getWorkRecords(),
+  ]);
+
+  return (
+    <HomePage
+      initialTasks={tasks}
+      initialCategories={categories}
+      initialWorkRecords={workRecords}
+    />
+  );
 }

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,5 +1,8 @@
+import { getCategories, getTasks } from "@/shared/lib/api/server";
 import { SettingsPage } from "@/views/settings";
 
-export default function Page() {
-  return <SettingsPage />;
+export default async function Page() {
+  const [tasks, categories] = await Promise.all([getTasks(), getCategories()]);
+
+  return <SettingsPage initialTasks={tasks} initialCategories={categories} />;
 }

--- a/apps/web/src/app/tasks/page.tsx
+++ b/apps/web/src/app/tasks/page.tsx
@@ -1,5 +1,8 @@
+import { getCategories, getTasks } from "@/shared/lib/api/server";
 import { TasksPage } from "@/views/tasks";
 
-export default function Page() {
-  return <TasksPage />;
+export default async function Page() {
+  const [tasks, categories] = await Promise.all([getTasks(), getCategories()]);
+
+  return <TasksPage initialTasks={tasks} initialCategories={categories} />;
 }

--- a/apps/web/src/app/timer/page.tsx
+++ b/apps/web/src/app/timer/page.tsx
@@ -1,5 +1,22 @@
+import {
+  getCategories,
+  getCurrentTimerSession,
+  getTasks,
+} from "@/shared/lib/api/server";
 import { TimerPage } from "@/views/timer";
 
-export default function Page() {
-  return <TimerPage />;
+export default async function Page() {
+  const [tasks, categories, timerSession] = await Promise.all([
+    getTasks(),
+    getCategories(),
+    getCurrentTimerSession(),
+  ]);
+
+  return (
+    <TimerPage
+      initialTasks={tasks}
+      initialCategories={categories}
+      initialTimerSession={timerSession}
+    />
+  );
 }

--- a/apps/web/src/shared/hooks/__tests__/query-client-wrapper.tsx
+++ b/apps/web/src/shared/hooks/__tests__/query-client-wrapper.tsx
@@ -1,0 +1,20 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+export function createQueryClientWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return {
+    queryClient,
+    wrapper,
+  };
+}

--- a/apps/web/src/shared/hooks/__tests__/use-tasks-category.test.ts
+++ b/apps/web/src/shared/hooks/__tests__/use-tasks-category.test.ts
@@ -1,117 +1,126 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { useTasks } from "@/shared/hooks/use-tasks";
+import * as api from "@/shared/lib/api";
+import type { Category, Task } from "@/shared/types/task";
+
+import { createQueryClientWrapper } from "./query-client-wrapper";
+
+vi.mock("@/shared/lib/api", () => ({
+  createCategory: vi.fn(),
+  createTask: vi.fn(),
+  deleteCategory: vi.fn(),
+  deleteTask: vi.fn(),
+  fetchCategories: vi.fn(),
+  fetchTasks: vi.fn(),
+  updateCategory: vi.fn(),
+  updateTask: vi.fn(),
+}));
+
+const now = "2026-01-01T00:00:00.000Z";
+
+const makeCategory = (overrides: Partial<Category> = {}): Category => ({
+  id: "category-1",
+  name: "インスタ投稿",
+  color: "#3B82F6",
+  ...overrides,
+});
+
+const makeTask = (overrides: Partial<Task> = {}): Task => ({
+  id: "task-1",
+  name: "タスク",
+  categoryId: "",
+  status: "todo",
+  isNext: false,
+  estimatedMinutes: null,
+  scheduledDate: null,
+  createdAt: now,
+  updatedAt: now,
+  ...overrides,
+});
+
+function renderUseTasks(tasks: Task[] = [], categories: Category[] = []) {
+  vi.mocked(api.fetchTasks).mockResolvedValue(tasks);
+  vi.mocked(api.fetchCategories).mockResolvedValue(categories);
+
+  const { wrapper } = createQueryClientWrapper();
+  return renderHook(() => useTasks({ tasks, categories }), { wrapper });
+}
 
 describe("useTasks - カテゴリ操作", () => {
-  let uuidCounter: number;
-
   beforeEach(() => {
-    localStorage.clear();
-    uuidCounter = 0;
-    vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
-      uuidCounter++;
-      return `uuid-${uuidCounter}`;
-    });
+    vi.clearAllMocks();
   });
 
-  it("addCategoryでカテゴリを追加できる", () => {
-    const { result } = renderHook(() => useTasks());
+  it("addCategoryでカテゴリを追加できる", async () => {
+    const createdCategory = makeCategory();
+    vi.mocked(api.createCategory).mockResolvedValue(createdCategory);
 
-    act(() => {
-      result.current.addCategory("インスタ投稿", "#3B82F6");
+    const { result } = renderUseTasks();
+
+    await act(async () => {
+      await result.current.addCategory(
+        createdCategory.name,
+        createdCategory.color,
+      );
     });
 
-    expect(result.current.categories).toHaveLength(1);
+    await waitFor(() => expect(result.current.categories).toHaveLength(1));
     expect(result.current.categories[0].name).toBe("インスタ投稿");
     expect(result.current.categories[0].color).toBe("#3B82F6");
   });
 
-  it("カテゴリIDが設定されたタスクにcategoryが解決される", () => {
-    const { result } = renderHook(() => useTasks());
+  it("updateCategoryでカテゴリの名前と色を更新できる", async () => {
+    const category = makeCategory();
+    vi.mocked(api.updateCategory).mockResolvedValue(
+      makeCategory({
+        id: category.id,
+        name: "ブログ執筆",
+        color: "#22C55E",
+      }),
+    );
 
-    act(() => {
-      result.current.addCategory("リサーチ", "#22C55E");
+    const { result } = renderUseTasks([], [category]);
+
+    await act(async () => {
+      await result.current.updateCategory(category.id, "ブログ執筆", "#22C55E");
     });
 
-    const categoryId = result.current.categories[0].id;
-
-    act(() => {
-      result.current.addTask({
-        name: "リサーチタスク",
-        categoryId,
-        scheduledDate: null,
-        estimatedMinutes: null,
-      });
-    });
-
-    expect(result.current.tasks[0].category.name).toBe("リサーチ");
-    expect(result.current.tasks[0].category.color).toBe("#22C55E");
-  });
-
-  it("updateCategoryでカテゴリの名前と色を更新できる", () => {
-    const { result } = renderHook(() => useTasks());
-
-    act(() => {
-      result.current.addCategory("インスタ投稿", "#3B82F6");
-    });
-
-    const categoryId = result.current.categories[0].id;
-
-    act(() => {
-      result.current.updateCategory(categoryId, "ブログ執筆", "#22C55E");
-    });
-
-    expect(result.current.categories[0].name).toBe("ブログ執筆");
+    await waitFor(() =>
+      expect(result.current.categories[0].name).toBe("ブログ執筆"),
+    );
     expect(result.current.categories[0].color).toBe("#22C55E");
-    expect(result.current.categories[0].id).toBe(categoryId);
+    expect(result.current.categories[0].id).toBe(category.id);
   });
 
-  it("deleteCategoryでカテゴリを削除できる", () => {
-    const { result } = renderHook(() => useTasks());
+  it("deleteCategoryでカテゴリを削除できる", async () => {
+    const category = makeCategory();
+    vi.mocked(api.deleteCategory).mockResolvedValue(undefined);
 
-    act(() => {
-      result.current.addCategory("インスタ投稿", "#3B82F6");
+    const { result } = renderUseTasks([], [category]);
+
+    await act(async () => {
+      await result.current.deleteCategory(category.id);
     });
 
-    const categoryId = result.current.categories[0].id;
-
-    act(() => {
-      result.current.deleteCategory(categoryId);
-    });
-
-    expect(result.current.categories).toHaveLength(0);
+    await waitFor(() => expect(result.current.categories).toHaveLength(0));
   });
 
-  it("deleteCategoryで紐づくタスクのcategoryIdが空文字になる", () => {
-    const { result } = renderHook(() => useTasks());
+  it("deleteCategoryで紐づくタスクのcategoryIdが空文字になる", async () => {
+    const category = makeCategory();
+    const tasks = [
+      makeTask({ id: "task-1", categoryId: category.id }),
+      makeTask({ id: "task-2", categoryId: "" }),
+    ];
+    vi.mocked(api.deleteCategory).mockResolvedValue(undefined);
 
-    act(() => {
-      result.current.addCategory("インスタ投稿", "#3B82F6");
+    const { result } = renderUseTasks(tasks, [category]);
+
+    await act(async () => {
+      await result.current.deleteCategory(category.id);
     });
 
-    const categoryId = result.current.categories[0].id;
-
-    act(() => {
-      result.current.addTask({
-        name: "紐づくタスク",
-        categoryId,
-        scheduledDate: null,
-        estimatedMinutes: null,
-      });
-      result.current.addTask({
-        name: "紐づかないタスク",
-        categoryId: "",
-        scheduledDate: null,
-        estimatedMinutes: null,
-      });
-    });
-
-    act(() => {
-      result.current.deleteCategory(categoryId);
-    });
-
-    expect(result.current.tasks[0].categoryId).toBe("");
+    await waitFor(() => expect(result.current.tasks[0].categoryId).toBe(""));
     expect(result.current.tasks[1].categoryId).toBe("");
     expect(result.current.categories).toHaveLength(0);
   });

--- a/apps/web/src/shared/hooks/__tests__/use-tasks.test.ts
+++ b/apps/web/src/shared/hooks/__tests__/use-tasks.test.ts
@@ -1,41 +1,75 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { useTasks } from "@/shared/hooks/use-tasks";
+import * as api from "@/shared/lib/api";
+import type { Category, Task } from "@/shared/types/task";
 
-vi.stubGlobal(
-  "crypto",
-  Object.assign({}, crypto, {
-    randomUUID: () => {
-      let counter = 0;
-      return () => `uuid-${++counter}`;
-    },
-  }),
-);
+import { createQueryClientWrapper } from "./query-client-wrapper";
+
+vi.mock("@/shared/lib/api", () => ({
+  createCategory: vi.fn(),
+  createTask: vi.fn(),
+  deleteCategory: vi.fn(),
+  deleteTask: vi.fn(),
+  fetchCategories: vi.fn(),
+  fetchTasks: vi.fn(),
+  updateCategory: vi.fn(),
+  updateTask: vi.fn(),
+}));
+
+const now = "2026-01-01T00:00:00.000Z";
+
+const makeTask = (overrides: Partial<Task> = {}): Task => ({
+  id: "task-1",
+  name: "テストタスク",
+  categoryId: "",
+  status: "todo",
+  isNext: false,
+  estimatedMinutes: null,
+  scheduledDate: null,
+  createdAt: now,
+  updatedAt: now,
+  ...overrides,
+});
+
+const makeCategory = (overrides: Partial<Category> = {}): Category => ({
+  id: "category-1",
+  name: "カテゴリ",
+  color: "#3B82F6",
+  ...overrides,
+});
+
+function renderUseTasks(tasks: Task[] = [], categories: Category[] = []) {
+  vi.mocked(api.fetchTasks).mockResolvedValue(tasks);
+  vi.mocked(api.fetchCategories).mockResolvedValue(categories);
+
+  const { wrapper } = createQueryClientWrapper();
+  return renderHook(() => useTasks({ tasks, categories }), { wrapper });
+}
 
 describe("useTasks", () => {
-  let uuidCounter: number;
-
   beforeEach(() => {
-    localStorage.clear();
-    uuidCounter = 0;
-    vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
-      uuidCounter++;
-      return `uuid-${uuidCounter}`;
-    });
+    vi.clearAllMocks();
   });
 
   it("初期状態では空のタスクとカテゴリを返す", () => {
-    const { result } = renderHook(() => useTasks());
+    const { result } = renderUseTasks();
+
     expect(result.current.tasks).toEqual([]);
     expect(result.current.categories).toEqual([]);
   });
 
-  it("addTaskでタスクを追加できる", () => {
-    const { result } = renderHook(() => useTasks());
+  it("addTaskでタスクを追加できる", async () => {
+    vi.mocked(api.createTask).mockResolvedValue(
+      makeTask({
+        estimatedMinutes: 30,
+      }),
+    );
 
-    act(() => {
-      result.current.addTask({
+    const { result } = renderUseTasks();
+
+    await act(async () => {
+      await result.current.addTask({
         name: "テストタスク",
         categoryId: "",
         scheduledDate: null,
@@ -43,29 +77,28 @@ describe("useTasks", () => {
       });
     });
 
-    expect(result.current.tasks).toHaveLength(1);
+    await waitFor(() => expect(result.current.tasks).toHaveLength(1));
     expect(result.current.tasks[0].name).toBe("テストタスク");
     expect(result.current.tasks[0].status).toBe("todo");
     expect(result.current.tasks[0].isNext).toBe(false);
     expect(result.current.tasks[0].estimatedMinutes).toBe(30);
   });
 
-  it("updateTaskでタスクを更新できる", () => {
-    const { result } = renderHook(() => useTasks());
+  it("updateTaskでタスクを更新できる", async () => {
+    const task = makeTask();
+    vi.mocked(api.updateTask).mockResolvedValue(
+      makeTask({
+        id: task.id,
+        name: "更新後のタスク",
+        scheduledDate: "2026-03-01",
+        estimatedMinutes: 60,
+      }),
+    );
 
-    act(() => {
-      result.current.addTask({
-        name: "元のタスク",
-        categoryId: "",
-        scheduledDate: null,
-        estimatedMinutes: null,
-      });
-    });
+    const { result } = renderUseTasks([task]);
 
-    const taskId = result.current.tasks[0].id;
-
-    act(() => {
-      result.current.updateTask(taskId, {
+    await act(async () => {
+      await result.current.updateTask(task.id, {
         name: "更新後のタスク",
         categoryId: "",
         scheduledDate: "2026-03-01",
@@ -73,196 +106,161 @@ describe("useTasks", () => {
       });
     });
 
-    expect(result.current.tasks[0].name).toBe("更新後のタスク");
+    await waitFor(() =>
+      expect(result.current.tasks[0].name).toBe("更新後のタスク"),
+    );
     expect(result.current.tasks[0].scheduledDate).toBe("2026-03-01");
     expect(result.current.tasks[0].estimatedMinutes).toBe(60);
   });
 
-  it("deleteTaskでタスクを削除できる", () => {
-    const { result } = renderHook(() => useTasks());
+  it("deleteTaskでタスクを削除できる", async () => {
+    const task = makeTask();
+    vi.mocked(api.deleteTask).mockResolvedValue(undefined);
 
-    act(() => {
-      result.current.addTask({
-        name: "削除するタスク",
-        categoryId: "",
-        scheduledDate: null,
-        estimatedMinutes: null,
-      });
+    const { result } = renderUseTasks([task]);
+
+    await act(async () => {
+      await result.current.deleteTask(task.id);
     });
 
-    const taskId = result.current.tasks[0].id;
-
-    act(() => {
-      result.current.deleteTask(taskId);
-    });
-
-    expect(result.current.tasks).toHaveLength(0);
+    await waitFor(() => expect(result.current.tasks).toHaveLength(0));
   });
 
-  it("toggleCompleteでタスクの完了を切り替えられる", () => {
-    const { result } = renderHook(() => useTasks());
+  it("toggleCompleteでタスクの完了を切り替えられる", async () => {
+    const task = makeTask();
+    vi.mocked(api.updateTask)
+      .mockResolvedValueOnce(makeTask({ id: task.id, status: "done" }))
+      .mockResolvedValueOnce(makeTask({ id: task.id, status: "todo" }));
 
-    act(() => {
-      result.current.addTask({
-        name: "完了テスト",
-        categoryId: "",
-        scheduledDate: null,
-        estimatedMinutes: null,
-      });
+    const { result } = renderUseTasks([task]);
+
+    await act(async () => {
+      await result.current.toggleComplete(task.id);
     });
 
-    const taskId = result.current.tasks[0].id;
+    await waitFor(() => expect(result.current.tasks[0].status).toBe("done"));
 
-    act(() => {
-      result.current.toggleComplete(taskId);
+    await act(async () => {
+      await result.current.toggleComplete(task.id);
     });
 
-    expect(result.current.tasks[0].status).toBe("done");
-
-    act(() => {
-      result.current.toggleComplete(taskId);
-    });
-
-    expect(result.current.tasks[0].status).toBe("todo");
+    await waitFor(() => expect(result.current.tasks[0].status).toBe("todo"));
   });
 
-  it("完了時にisNextがtrueのタスクは自動でisNextがfalseになる", () => {
-    const { result } = renderHook(() => useTasks());
+  it("完了時にisNextがtrueのタスクは自動でisNextがfalseになる", async () => {
+    const task = makeTask({ isNext: true });
+    vi.mocked(api.updateTask).mockResolvedValue(
+      makeTask({
+        id: task.id,
+        status: "done",
+        isNext: false,
+      }),
+    );
 
-    act(() => {
-      result.current.addTask({
-        name: "次やるタスク",
-        categoryId: "",
-        scheduledDate: null,
-        estimatedMinutes: null,
-      });
+    const { result } = renderUseTasks([task]);
+
+    await act(async () => {
+      await result.current.toggleComplete(task.id);
     });
 
-    const taskId = result.current.tasks[0].id;
-
-    act(() => {
-      result.current.setNextTask(taskId);
-    });
-
-    expect(result.current.tasks[0].isNext).toBe(true);
-
-    act(() => {
-      result.current.toggleComplete(taskId);
-    });
-
-    expect(result.current.tasks[0].status).toBe("done");
+    await waitFor(() => expect(result.current.tasks[0].status).toBe("done"));
     expect(result.current.tasks[0].isNext).toBe(false);
   });
 
-  it("setNextTaskで「次やる」を設定すると他のタスクのisNextが解除される", () => {
-    const { result } = renderHook(() => useTasks());
-
-    act(() => {
-      result.current.addTask({
-        name: "タスク1",
-        categoryId: "",
-        scheduledDate: null,
-        estimatedMinutes: null,
-      });
-      result.current.addTask({
-        name: "タスク2",
-        categoryId: "",
-        scheduledDate: null,
-        estimatedMinutes: null,
+  it("setNextTaskで「次やる」を設定すると他のタスクのisNextが解除される", async () => {
+    const tasks = [makeTask({ id: "task-1" }), makeTask({ id: "task-2" })];
+    vi.mocked(api.updateTask).mockImplementation(async (id, input) => {
+      const task = tasks.find((candidate) => candidate.id === id)!;
+      return makeTask({
+        ...task,
+        ...input,
+        id,
+        categoryId: (input.categoryId ?? "") as string,
       });
     });
 
-    const task1Id = result.current.tasks[0].id;
-    const task2Id = result.current.tasks[1].id;
+    const { result } = renderUseTasks(tasks);
 
-    act(() => {
-      result.current.setNextTask(task1Id);
+    await act(async () => {
+      await result.current.setNextTask("task-1");
     });
 
-    expect(result.current.tasks[0].isNext).toBe(true);
+    await waitFor(() => expect(result.current.tasks[0].isNext).toBe(true));
     expect(result.current.tasks[1].isNext).toBe(false);
 
-    act(() => {
-      result.current.setNextTask(task2Id);
+    await act(async () => {
+      await result.current.setNextTask("task-2");
     });
 
-    expect(result.current.tasks[0].isNext).toBe(false);
+    await waitFor(() => expect(result.current.tasks[0].isNext).toBe(false));
     expect(result.current.tasks[1].isNext).toBe(true);
   });
 
-  it("unsetNextTaskで「次やる」を解除できる", () => {
-    const { result } = renderHook(() => useTasks());
+  it("unsetNextTaskで「次やる」を解除できる", async () => {
+    const task = makeTask({ isNext: true });
+    vi.mocked(api.updateTask).mockResolvedValue(
+      makeTask({
+        id: task.id,
+        isNext: false,
+      }),
+    );
 
-    act(() => {
-      result.current.addTask({
-        name: "タスク",
-        categoryId: "",
-        scheduledDate: null,
-        estimatedMinutes: null,
-      });
+    const { result } = renderUseTasks([task]);
+
+    await act(async () => {
+      await result.current.unsetNextTask(task.id);
     });
 
-    const taskId = result.current.tasks[0].id;
+    await waitFor(() => expect(result.current.tasks[0].isNext).toBe(false));
+  });
 
-    act(() => {
-      result.current.setNextTask(taskId);
+  it("startWorkでステータスがin_progressになる", async () => {
+    const task = makeTask();
+    vi.mocked(api.updateTask).mockResolvedValue(
+      makeTask({
+        id: task.id,
+        status: "in_progress",
+      }),
+    );
+
+    const { result } = renderUseTasks([task]);
+
+    await act(async () => {
+      await result.current.startWork(task.id);
     });
 
-    expect(result.current.tasks[0].isNext).toBe(true);
+    await waitFor(() =>
+      expect(result.current.tasks[0].status).toBe("in_progress"),
+    );
+  });
 
-    act(() => {
-      result.current.unsetNextTask(taskId);
+  it("completeTaskでステータスがdoneになりisNextがfalseになる", async () => {
+    const task = makeTask({ isNext: true, status: "in_progress" });
+    vi.mocked(api.updateTask).mockResolvedValue(
+      makeTask({
+        id: task.id,
+        status: "done",
+        isNext: false,
+      }),
+    );
+
+    const { result } = renderUseTasks([task]);
+
+    await act(async () => {
+      await result.current.completeTask(task.id);
     });
 
+    await waitFor(() => expect(result.current.tasks[0].status).toBe("done"));
     expect(result.current.tasks[0].isNext).toBe(false);
   });
 
-  it("startWorkでステータスがin_progressになる", () => {
-    const { result } = renderHook(() => useTasks());
+  it("categoryIdがあるタスクにcategory情報を解決する", () => {
+    const category = makeCategory();
+    const task = makeTask({ categoryId: category.id });
 
-    act(() => {
-      result.current.addTask({
-        name: "作業開始テスト",
-        categoryId: "",
-        scheduledDate: null,
-        estimatedMinutes: null,
-      });
-    });
+    const { result } = renderUseTasks([task], [category]);
 
-    const taskId = result.current.tasks[0].id;
-
-    act(() => {
-      result.current.startWork(taskId);
-    });
-
-    expect(result.current.tasks[0].status).toBe("in_progress");
-  });
-
-  it("completeTaskでステータスがdoneになりisNextがfalseになる", () => {
-    const { result } = renderHook(() => useTasks());
-
-    act(() => {
-      result.current.addTask({
-        name: "完了テスト",
-        categoryId: "",
-        scheduledDate: null,
-        estimatedMinutes: null,
-      });
-    });
-
-    const taskId = result.current.tasks[0].id;
-
-    act(() => {
-      result.current.setNextTask(taskId);
-    });
-
-    expect(result.current.tasks[0].isNext).toBe(true);
-
-    act(() => {
-      result.current.completeTask(taskId);
-    });
-
-    expect(result.current.tasks[0].status).toBe("done");
-    expect(result.current.tasks[0].isNext).toBe(false);
+    expect(result.current.tasks[0].category.name).toBe(category.name);
+    expect(result.current.tasks[0].category.color).toBe(category.color);
   });
 });

--- a/apps/web/src/shared/hooks/__tests__/use-timer.test.ts
+++ b/apps/web/src/shared/hooks/__tests__/use-timer.test.ts
@@ -1,7 +1,16 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTimer } from "@/shared/hooks/use-timer";
+import * as api from "@/shared/lib/api";
+import type { TimerSession } from "@/shared/types/timer";
 
-import { TIMER_SESSION_KEY, useTimer } from "@/shared/hooks/use-timer";
+import { createQueryClientWrapper } from "./query-client-wrapper";
+
+vi.mock("@/shared/lib/api", () => ({
+  createTimerSession: vi.fn(),
+  deleteCurrentTimerSession: vi.fn(),
+  fetchCurrentTimerSession: vi.fn(),
+}));
 
 const DEFAULT_INPUT = {
   taskId: "task-1",
@@ -10,9 +19,25 @@ const DEFAULT_INPUT = {
   estimatedMinutes: 25,
 };
 
+const makeSession = (overrides: Partial<TimerSession> = {}): TimerSession => ({
+  taskId: "task-1",
+  taskName: "テストタスク",
+  categoryName: "カテゴリ1",
+  estimatedMinutes: 25,
+  startedAt: "2026-02-26T10:00:00.000Z",
+  ...overrides,
+});
+
+function renderUseTimer(initialSession: TimerSession | null = null) {
+  vi.mocked(api.fetchCurrentTimerSession).mockResolvedValue(initialSession);
+
+  const { wrapper } = createQueryClientWrapper();
+  return renderHook(() => useTimer(DEFAULT_INPUT, initialSession), { wrapper });
+}
+
 describe("useTimer", () => {
   beforeEach(() => {
-    localStorage.clear();
+    vi.clearAllMocks();
     vi.useFakeTimers();
   });
 
@@ -21,102 +46,138 @@ describe("useTimer", () => {
   });
 
   it("初期状態ではタイマーは停止している", () => {
-    const { result } = renderHook(() => useTimer(DEFAULT_INPUT));
+    const { result } = renderUseTimer();
 
     expect(result.current.isRunning).toBe(false);
     expect(result.current.isFinished).toBe(false);
     expect(result.current.remainingSeconds).toBe(25 * 60);
   });
 
-  it("start でタイマーが開始され、セッションが localStorage に保存される", () => {
-    const { result } = renderHook(() => useTimer(DEFAULT_INPUT));
-
-    act(() => {
-      result.current.start();
-    });
-
-    expect(result.current.isRunning).toBe(true);
-    expect(result.current.isFinished).toBe(false);
-
-    const stored = JSON.parse(localStorage.getItem(TIMER_SESSION_KEY)!);
-    expect(stored.taskId).toBe("task-1");
-    expect(stored.taskName).toBe("テストタスク");
-    expect(stored.estimatedMinutes).toBe(25);
-  });
-
-  it("complete でセッションが削除され、作業結果が返される", () => {
+  it("startでタイマーが開始される", async () => {
     vi.setSystemTime(new Date("2026-02-26T10:00:00Z"));
 
-    const { result } = renderHook(() => useTimer(DEFAULT_INPUT));
+    const createdSession = makeSession();
+    vi.mocked(api.createTimerSession).mockResolvedValue(createdSession);
 
-    act(() => {
-      result.current.start();
+    const { result } = renderUseTimer();
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(vi.mocked(api.createTimerSession).mock.calls[0]?.[0]).toEqual(
+      DEFAULT_INPUT,
+    );
+    expect(result.current.isRunning).toBe(true);
+    expect(result.current.isFinished).toBe(false);
+  });
+
+  it("completeでセッションが削除され、作業結果が返される", async () => {
+    vi.setSystemTime(new Date("2026-02-26T10:00:00Z"));
+
+    const createdSession = makeSession();
+    vi.mocked(api.createTimerSession).mockResolvedValue(createdSession);
+    vi.mocked(api.deleteCurrentTimerSession).mockResolvedValue(undefined);
+
+    const { result } = renderUseTimer();
+
+    await act(async () => {
+      await result.current.start();
     });
 
     vi.setSystemTime(new Date("2026-02-26T10:15:00Z"));
 
-    let timerResult: ReturnType<typeof result.current.complete>;
-    act(() => {
-      timerResult = result.current.complete();
+    let timerResult:
+      | Awaited<ReturnType<typeof result.current.complete>>
+      | undefined;
+    await act(async () => {
+      timerResult = await result.current.complete();
     });
 
-    expect(timerResult!.taskId).toBe("task-1");
-    expect(timerResult!.durationMinutes).toBe(15);
+    expect(timerResult?.taskId).toBe("task-1");
+    expect(timerResult?.durationMinutes).toBe(15);
+    expect(api.deleteCurrentTimerSession).toHaveBeenCalled();
     expect(result.current.isRunning).toBe(false);
-    expect(localStorage.getItem(TIMER_SESSION_KEY)).toBe("null");
   });
 
-  it("interrupt でセッションが削除され、作業結果が返される", () => {
+  it("interruptでセッションが削除され、作業結果が返される", async () => {
     vi.setSystemTime(new Date("2026-02-26T10:00:00Z"));
 
-    const { result } = renderHook(() => useTimer(DEFAULT_INPUT));
+    const createdSession = makeSession();
+    vi.mocked(api.createTimerSession).mockResolvedValue(createdSession);
+    vi.mocked(api.deleteCurrentTimerSession).mockResolvedValue(undefined);
 
-    act(() => {
-      result.current.start();
+    const { result } = renderUseTimer();
+
+    await act(async () => {
+      await result.current.start();
     });
 
     vi.setSystemTime(new Date("2026-02-26T10:10:00Z"));
 
-    let timerResult: ReturnType<typeof result.current.interrupt>;
-    act(() => {
-      timerResult = result.current.interrupt();
+    let timerResult:
+      | Awaited<ReturnType<typeof result.current.interrupt>>
+      | undefined;
+    await act(async () => {
+      timerResult = await result.current.interrupt();
     });
 
-    expect(timerResult!.taskId).toBe("task-1");
-    expect(timerResult!.durationMinutes).toBe(10);
+    expect(timerResult?.taskId).toBe("task-1");
+    expect(timerResult?.durationMinutes).toBe(10);
     expect(result.current.isRunning).toBe(false);
   });
 
-  it("restart でタイマーがリセットされて再開する", () => {
-    const { result } = renderHook(() => useTimer(DEFAULT_INPUT));
-
-    act(() => {
-      result.current.start();
-    });
-
-    act(() => {
-      result.current.restart();
-    });
-
-    expect(result.current.isRunning).toBe(true);
-    expect(result.current.isFinished).toBe(false);
-    expect(result.current.remainingSeconds).toBe(25 * 60);
-  });
-
-  it("カウントダウンが0になると isFinished が true になる", () => {
+  it("restartでタイマーがリセットされて再開する", async () => {
     vi.setSystemTime(new Date("2026-02-26T10:00:00Z"));
 
-    const input = { ...DEFAULT_INPUT, estimatedMinutes: 1 };
-    const { result } = renderHook(() => useTimer(input));
+    vi.mocked(api.createTimerSession)
+      .mockResolvedValueOnce(makeSession())
+      .mockResolvedValueOnce(
+        makeSession({
+          startedAt: "2026-02-26T10:05:00.000Z",
+        }),
+      );
+    vi.mocked(api.deleteCurrentTimerSession).mockResolvedValue(undefined);
 
-    act(() => {
-      result.current.start();
+    const { result } = renderUseTimer();
+
+    await act(async () => {
+      await result.current.start();
     });
+
+    await act(async () => {
+      await result.current.restart();
+    });
+
+    expect(api.createTimerSession).toHaveBeenCalledTimes(2);
+    expect(api.deleteCurrentTimerSession).toHaveBeenCalledTimes(1);
+    expect(result.current.isRunning).toBe(true);
+    expect(result.current.isFinished).toBe(false);
+  });
+
+  it("カウントダウンが0になるとisFinishedがtrueになる", async () => {
+    vi.setSystemTime(new Date("2026-02-26T10:00:00Z"));
+
+    const session = makeSession({
+      estimatedMinutes: 1,
+      startedAt: "2026-02-26T10:00:00.000Z",
+    });
+    const { result } = renderHook(
+      () =>
+        useTimer(
+          {
+            ...DEFAULT_INPUT,
+            estimatedMinutes: 1,
+          },
+          session,
+        ),
+      { wrapper: createQueryClientWrapper().wrapper },
+    );
 
     vi.setSystemTime(new Date("2026-02-26T10:01:01Z"));
 
     act(() => {
-      vi.advanceTimersByTime(61000);
+      vi.advanceTimersByTime(61_000);
     });
 
     expect(result.current.isFinished).toBe(true);
@@ -124,21 +185,12 @@ describe("useTimer", () => {
   });
 
   it("既存のセッションがある場合、残り時間を復元する", () => {
-    const startedAt = new Date("2026-02-26T10:00:00Z").toISOString();
-    localStorage.setItem(
-      TIMER_SESSION_KEY,
-      JSON.stringify({
-        taskId: "task-1",
-        taskName: "テストタスク",
-        categoryName: "カテゴリ1",
-        estimatedMinutes: 25,
-        startedAt,
-      }),
-    );
-
+    const session = makeSession({
+      startedAt: "2026-02-26T10:00:00.000Z",
+    });
     vi.setSystemTime(new Date("2026-02-26T10:10:00Z"));
 
-    const { result } = renderHook(() => useTimer(DEFAULT_INPUT));
+    const { result } = renderUseTimer(session);
 
     expect(result.current.isRunning).toBe(true);
     expect(result.current.remainingSeconds).toBe(15 * 60);

--- a/apps/web/src/shared/hooks/__tests__/use-work-records.test.ts
+++ b/apps/web/src/shared/hooks/__tests__/use-work-records.test.ts
@@ -1,73 +1,71 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { useWorkRecords } from "@/shared/hooks/use-work-records";
+import * as api from "@/shared/lib/api";
 
 import type { TaskWithCategory } from "@/shared/types/task";
 import type { WorkRecord } from "@/shared/types/work-record";
 
+import { createQueryClientWrapper } from "./query-client-wrapper";
+
+vi.mock("@/shared/lib/api", () => ({
+  createWorkRecord: vi.fn(),
+  fetchWorkRecords: vi.fn(),
+}));
+
 const makeTasks = (
   overrides: Partial<TaskWithCategory>[] = [],
 ): TaskWithCategory[] =>
-  overrides.map((o, i) => ({
-    id: `task-${i + 1}`,
-    name: `タスク${i + 1}`,
-    categoryId: `cat-${i + 1}`,
-    status: "todo" as const,
+  overrides.map((override, index) => ({
+    id: `task-${index + 1}`,
+    name: `タスク${index + 1}`,
+    categoryId: `cat-${index + 1}`,
+    status: "todo",
     isNext: false,
     estimatedMinutes: null,
     scheduledDate: null,
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
-    category: { id: `cat-${i + 1}`, name: `カテゴリ${i + 1}`, color: "#000" },
-    ...o,
+    category: {
+      id: `cat-${index + 1}`,
+      name: `カテゴリ${index + 1}`,
+      color: "#000",
+    },
+    ...override,
   }));
 
 const makeRecord = (
   overrides: Partial<WorkRecord> & { taskId: string; date: string },
 ): WorkRecord => ({
-  id: `record-${Math.random()}`,
+  id: "record-1",
   durationMinutes: 30,
-  result: "completed" as const,
+  result: "completed",
   ...overrides,
 });
 
+function renderUseWorkRecords(
+  tasks: TaskWithCategory[],
+  workRecords: WorkRecord[] = [],
+) {
+  vi.mocked(api.fetchWorkRecords).mockResolvedValue(workRecords);
+
+  const { wrapper } = createQueryClientWrapper();
+  return renderHook(() => useWorkRecords(tasks, { workRecords }), { wrapper });
+}
+
 describe("useWorkRecords", () => {
   beforeEach(() => {
-    localStorage.clear();
-    vi.spyOn(crypto, "randomUUID").mockReturnValue("mock-uuid");
+    vi.clearAllMocks();
   });
 
   it("初期状態では空のデータを返す", () => {
-    const { result } = renderHook(() => useWorkRecords([]));
+    const { result } = renderUseWorkRecords([]);
+
     expect(result.current.recentWorkByDay).toEqual([]);
     expect(result.current.getWorkRecordsByMonth(2026, 2)).toEqual([]);
   });
 
-  it("localStorageに作業記録がある場合はそれを返す", () => {
-    const records: WorkRecord[] = [
-      makeRecord({
-        id: "r1",
-        taskId: "t1",
-        date: "2026-02-25",
-        durationMinutes: 30,
-      }),
-    ];
-    localStorage.setItem("work-records", JSON.stringify(records));
-
-    const tasks = makeTasks([
-      {
-        id: "t1",
-        name: "テスト",
-        category: { id: "c1", name: "Cat", color: "#000" },
-      },
-    ]);
-
-    const { result } = renderHook(() => useWorkRecords(tasks));
-    expect(result.current.recentWorkByDay).toHaveLength(1);
-  });
-
-  it("addWorkRecordで作業記録を追加できる", () => {
+  it("addWorkRecordで作業記録を追加できる", async () => {
     const tasks = makeTasks([
       {
         id: "t1",
@@ -75,11 +73,19 @@ describe("useWorkRecords", () => {
         category: { id: "c1", name: "カテA", color: "#f00" },
       },
     ]);
+    vi.mocked(api.createWorkRecord).mockResolvedValue(
+      makeRecord({
+        id: "r1",
+        taskId: "t1",
+        date: "2026-02-26",
+        durationMinutes: 25,
+      }),
+    );
 
-    const { result } = renderHook(() => useWorkRecords(tasks));
+    const { result } = renderUseWorkRecords(tasks);
 
-    act(() => {
-      result.current.addWorkRecord({
+    await act(async () => {
+      await result.current.addWorkRecord({
         taskId: "t1",
         date: "2026-02-26",
         durationMinutes: 25,
@@ -87,7 +93,7 @@ describe("useWorkRecords", () => {
       });
     });
 
-    expect(result.current.recentWorkByDay).toHaveLength(1);
+    await waitFor(() => expect(result.current.recentWorkByDay).toHaveLength(1));
     expect(result.current.recentWorkByDay[0].records[0].taskId).toBe("t1");
     expect(result.current.recentWorkByDay[0].records[0].durationMinutes).toBe(
       25,
@@ -95,7 +101,7 @@ describe("useWorkRecords", () => {
   });
 
   it("getWorkRecordsByMonthで指定月のレコードを返す", () => {
-    const records: WorkRecord[] = [
+    const records = [
       makeRecord({
         id: "r1",
         taskId: "t1",
@@ -115,8 +121,6 @@ describe("useWorkRecords", () => {
         durationMinutes: 60,
       }),
     ];
-    localStorage.setItem("work-records", JSON.stringify(records));
-
     const tasks = makeTasks([
       {
         id: "t1",
@@ -125,7 +129,7 @@ describe("useWorkRecords", () => {
       },
     ]);
 
-    const { result } = renderHook(() => useWorkRecords(tasks));
+    const { result } = renderUseWorkRecords(tasks, records);
     const febRecords = result.current.getWorkRecordsByMonth(2026, 2);
 
     expect(febRecords).toHaveLength(2);
@@ -134,16 +138,6 @@ describe("useWorkRecords", () => {
   });
 
   it("getWorkRecordsByMonthで該当レコードがなければ空配列を返す", () => {
-    const records: WorkRecord[] = [
-      makeRecord({
-        id: "r1",
-        taskId: "t1",
-        date: "2026-02-10",
-        durationMinutes: 30,
-      }),
-    ];
-    localStorage.setItem("work-records", JSON.stringify(records));
-
     const tasks = makeTasks([
       {
         id: "t1",
@@ -151,10 +145,16 @@ describe("useWorkRecords", () => {
         category: { id: "c1", name: "カテA", color: "#f00" },
       },
     ]);
+    const records = [
+      makeRecord({
+        id: "r1",
+        taskId: "t1",
+        date: "2026-02-10",
+      }),
+    ];
 
-    const { result } = renderHook(() => useWorkRecords(tasks));
-    const janRecords = result.current.getWorkRecordsByMonth(2026, 1);
+    const { result } = renderUseWorkRecords(tasks, records);
 
-    expect(janRecords).toEqual([]);
+    expect(result.current.getWorkRecordsByMonth(2026, 1)).toEqual([]);
   });
 });

--- a/apps/web/src/shared/hooks/use-current-timer-session.ts
+++ b/apps/web/src/shared/hooks/use-current-timer-session.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import {
+  createTimerSession,
+  deleteCurrentTimerSession,
+  fetchCurrentTimerSession,
+} from "@/shared/lib/api";
+import { queryKeys } from "@/shared/lib/api/query-keys";
+import type { TimerSession } from "@/shared/types/timer";
+
+export function useCurrentTimerSession(initialSession?: TimerSession | null) {
+  const queryClient = useQueryClient();
+  const { data: session = null } = useQuery({
+    queryKey: queryKeys.timerSession,
+    queryFn: fetchCurrentTimerSession,
+    initialData: initialSession,
+  });
+
+  const createSessionMutation = useMutation({
+    mutationFn: createTimerSession,
+    onSuccess: (createdSession) => {
+      queryClient.setQueryData(queryKeys.timerSession, createdSession);
+    },
+  });
+  const deleteSessionMutation = useMutation({
+    mutationFn: deleteCurrentTimerSession,
+    onSuccess: () => {
+      queryClient.setQueryData(queryKeys.timerSession, null);
+    },
+  });
+
+  const createSession = useCallback(
+    (input: Parameters<typeof createTimerSession>[0]) => {
+      return createSessionMutation.mutateAsync(input);
+    },
+    [createSessionMutation],
+  );
+
+  const clearSession = useCallback(async () => {
+    await deleteSessionMutation.mutateAsync();
+  }, [deleteSessionMutation]);
+
+  return {
+    session,
+    createSession,
+    clearSession,
+  };
+}

--- a/apps/web/src/shared/hooks/use-task-page-actions.tsx
+++ b/apps/web/src/shared/hooks/use-task-page-actions.tsx
@@ -7,11 +7,11 @@ import type { TaskFormData } from "@/shared/ui/add-task-modal";
 import { TaskActionList } from "@/shared/ui/task-action-list";
 
 type UseTaskPageActionsParams = {
-  addTask: (input: TaskFormData) => void;
-  updateTask: (id: string, input: TaskFormData) => void;
-  deleteTask: (id: string) => void;
-  setNextTask: (id: string) => void;
-  unsetNextTask: (id: string) => void;
+  addTask: (input: TaskFormData) => Promise<void>;
+  updateTask: (id: string, input: TaskFormData) => Promise<void>;
+  deleteTask: (id: string) => Promise<void>;
+  setNextTask: (id: string) => Promise<void>;
+  unsetNextTask: (id: string) => Promise<void>;
 };
 
 type UseTaskPageActionsReturn = {
@@ -21,10 +21,10 @@ type UseTaskPageActionsReturn = {
   handleToggleExpand: (taskId: string) => void;
   handleNavChange: (key: string) => void;
   handleStartWork: (taskId: string) => void;
-  handleAddTask: (data: TaskFormData) => void;
-  handleUpdateTask: (data: TaskFormData) => void;
+  handleAddTask: (data: TaskFormData) => Promise<void>;
+  handleUpdateTask: (data: TaskFormData) => Promise<void>;
   handleOpenEdit: (task: TaskWithCategory) => void;
-  handleConfirmDelete: () => void;
+  handleConfirmDelete: () => Promise<void>;
   setDeleteTarget: (target: TaskWithCategory | null) => void;
   setEditingTask: (task: (TaskFormData & { id: string }) | undefined) => void;
   renderActions: (task: TaskWithCategory) => React.ReactNode;
@@ -73,16 +73,16 @@ export function useTaskPageActions({
   );
 
   const handleAddTask = useCallback(
-    (data: TaskFormData) => {
-      addTask(data);
+    async (data: TaskFormData) => {
+      await addTask(data);
     },
     [addTask],
   );
 
   const handleUpdateTask = useCallback(
-    (data: TaskFormData) => {
+    async (data: TaskFormData) => {
       if (!editingTask) return;
-      updateTask(editingTask.id, data);
+      await updateTask(editingTask.id, data);
       setEditingTask(undefined);
     },
     [editingTask, updateTask],
@@ -99,9 +99,9 @@ export function useTaskPageActions({
     setExpandedTaskId(null);
   }, []);
 
-  const handleConfirmDelete = useCallback(() => {
+  const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return;
-    deleteTask(deleteTarget.id);
+    await deleteTask(deleteTarget.id);
     setDeleteTarget(null);
     setExpandedTaskId(null);
   }, [deleteTarget, deleteTask]);
@@ -110,11 +110,11 @@ export function useTaskPageActions({
     <TaskActionList
       isNext={task.isNext}
       onSetNext={() => {
-        setNextTask(task.id);
+        void setNextTask(task.id);
         setExpandedTaskId(null);
       }}
       onUnsetNext={() => {
-        unsetNextTask(task.id);
+        void unsetNextTask(task.id);
         setExpandedTaskId(null);
       }}
       onStartWork={() => handleStartWork(task.id)}

--- a/apps/web/src/shared/hooks/use-tasks.ts
+++ b/apps/web/src/shared/hooks/use-tasks.ts
@@ -1,9 +1,22 @@
 "use client";
 
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import type { TaskStatus } from "@/shared/enums/task-statuses";
-import { useLocalStorage } from "@/shared/hooks/use-local-storage";
+import {
+  createCategory,
+  createTask,
+  deleteCategory,
+  deleteTask,
+  fetchCategories,
+  fetchTasks,
+  updateCategory,
+  updateTask,
+} from "@/shared/lib/api";
+import { queryKeys } from "@/shared/lib/api/query-keys";
 import type { Category, Task, TaskWithCategory } from "@/shared/types/task";
+import type { TimerSession } from "@/shared/types/timer";
+import type { WorkRecord } from "@/shared/types/work-record";
 
 const UNCATEGORIZED: Category = {
   id: "",
@@ -25,219 +38,320 @@ type UpdateTaskInput = {
   estimatedMinutes: number | null;
 };
 
+export type TasksInitialData = {
+  categories: Category[];
+  tasks: Task[];
+};
+
 type UseTasksReturn = {
   tasks: TaskWithCategory[];
   categories: Category[];
-  addTask: (input: AddTaskInput) => void;
-  updateTask: (id: string, input: UpdateTaskInput) => void;
-  deleteTask: (id: string) => void;
-  toggleComplete: (id: string) => void;
-  setNextTask: (id: string) => void;
-  unsetNextTask: (id: string) => void;
-  startWork: (id: string) => void;
-  completeTask: (id: string) => void;
-  addCategory: (name: string, color: string) => string;
-  updateCategory: (id: string, name: string, color: string) => void;
-  deleteCategory: (id: string) => void;
+  addTask: (input: AddTaskInput) => Promise<void>;
+  updateTask: (id: string, input: UpdateTaskInput) => Promise<void>;
+  deleteTask: (id: string) => Promise<void>;
+  toggleComplete: (id: string) => Promise<void>;
+  setNextTask: (id: string) => Promise<void>;
+  unsetNextTask: (id: string) => Promise<void>;
+  startWork: (id: string) => Promise<void>;
+  completeTask: (id: string) => Promise<void>;
+  addCategory: (name: string, color: string) => Promise<string>;
+  updateCategory: (id: string, name: string, color: string) => Promise<void>;
+  deleteCategory: (id: string) => Promise<void>;
 };
 
-export function useTasks(): UseTasksReturn {
-  const { value: tasks, setValue: setTasks } = useLocalStorage<Task[]>(
-    "tasks",
-    [],
-  );
-  const { value: categories, setValue: setCategories } = useLocalStorage<
-    Category[]
-  >("categories", []);
+function normalizeCategoryId(categoryId: string) {
+  return categoryId === "" ? null : categoryId;
+}
+
+function toTaskMutationInput(
+  task: Task,
+  overrides: Partial<
+    Pick<
+      Task,
+      | "categoryId"
+      | "estimatedMinutes"
+      | "isNext"
+      | "name"
+      | "scheduledDate"
+      | "status"
+    >
+  >,
+) {
+  return {
+    name: overrides.name ?? task.name,
+    categoryId: normalizeCategoryId(overrides.categoryId ?? task.categoryId),
+    status: overrides.status ?? task.status,
+    isNext: overrides.isNext ?? task.isNext,
+    estimatedMinutes: overrides.estimatedMinutes ?? task.estimatedMinutes,
+    scheduledDate: overrides.scheduledDate ?? task.scheduledDate,
+  };
+}
+
+export function useTasks(initialData?: TasksInitialData): UseTasksReturn {
+  const queryClient = useQueryClient();
+
+  const { data: tasks = [] } = useQuery({
+    queryKey: queryKeys.tasks,
+    queryFn: fetchTasks,
+    initialData: initialData?.tasks,
+  });
+  const { data: categories = [] } = useQuery({
+    queryKey: queryKeys.categories,
+    queryFn: fetchCategories,
+    initialData: initialData?.categories,
+  });
+
+  const createTaskMutation = useMutation({
+    mutationFn: createTask,
+    onSuccess: (createdTask) => {
+      queryClient.setQueryData<Task[]>(queryKeys.tasks, (prev = []) => [
+        ...prev,
+        createdTask,
+      ]);
+    },
+  });
+  const updateTaskMutation = useMutation({
+    mutationFn: ({
+      id,
+      input,
+    }: {
+      id: string;
+      input: ReturnType<typeof toTaskMutationInput>;
+    }) => updateTask(id, input),
+    onSuccess: (updatedTask) => {
+      queryClient.setQueryData<Task[]>(queryKeys.tasks, (prev = []) =>
+        prev.map((task) => (task.id === updatedTask.id ? updatedTask : task)),
+      );
+    },
+  });
+  const deleteTaskMutation = useMutation({
+    mutationFn: deleteTask,
+    onSuccess: (_, deletedTaskId) => {
+      queryClient.setQueryData<Task[]>(queryKeys.tasks, (prev = []) =>
+        prev.filter((task) => task.id !== deletedTaskId),
+      );
+      queryClient.setQueryData<WorkRecord[]>(
+        queryKeys.workRecords,
+        (prev = []) => prev.filter((record) => record.taskId !== deletedTaskId),
+      );
+      queryClient.setQueryData<TimerSession | null>(
+        queryKeys.timerSession,
+        (prev) => (prev?.taskId === deletedTaskId ? null : (prev ?? null)),
+      );
+    },
+  });
+  const createCategoryMutation = useMutation({
+    mutationFn: createCategory,
+    onSuccess: (createdCategory) => {
+      queryClient.setQueryData<Category[]>(
+        queryKeys.categories,
+        (prev = []) => [...prev, createdCategory],
+      );
+    },
+  });
+  const updateCategoryMutation = useMutation({
+    mutationFn: ({
+      id,
+      color,
+      name,
+    }: {
+      id: string;
+      color: string;
+      name: string;
+    }) => updateCategory(id, { name, color }),
+    onSuccess: (updatedCategory) => {
+      queryClient.setQueryData<Category[]>(queryKeys.categories, (prev = []) =>
+        prev.map((category) =>
+          category.id === updatedCategory.id ? updatedCategory : category,
+        ),
+      );
+    },
+  });
+  const deleteCategoryMutation = useMutation({
+    mutationFn: deleteCategory,
+    onSuccess: (_, deletedCategoryId) => {
+      queryClient.setQueryData<Category[]>(queryKeys.categories, (prev = []) =>
+        prev.filter((category) => category.id !== deletedCategoryId),
+      );
+      queryClient.setQueryData<Task[]>(queryKeys.tasks, (prev = []) =>
+        prev.map((task) =>
+          task.categoryId === deletedCategoryId
+            ? { ...task, categoryId: "" }
+            : task,
+        ),
+      );
+    },
+  });
 
   const resolveCategory = useCallback(
     (categoryId: string): Category => {
-      return categories.find((c) => c.id === categoryId) ?? UNCATEGORIZED;
+      return (
+        categories.find((category) => category.id === categoryId) ??
+        UNCATEGORIZED
+      );
     },
     [categories],
   );
 
-  const tasksWithCategory: TaskWithCategory[] = useMemo(() => {
+  const tasksWithCategory = useMemo(() => {
     return tasks.map((task) => ({
       ...task,
       category: resolveCategory(task.categoryId),
     }));
   }, [tasks, resolveCategory]);
 
-  const addTask = useCallback(
-    (input: AddTaskInput) => {
-      const now = new Date().toISOString();
-      const newTask: Task = {
-        id: crypto.randomUUID(),
+  const mutateTask = useCallback(
+    async (
+      id: string,
+      recipe: (task: Task) => ReturnType<typeof toTaskMutationInput>,
+    ) => {
+      const currentTask = tasks.find((task) => task.id === id);
+      if (!currentTask) return;
+      await updateTaskMutation.mutateAsync({
+        id,
+        input: recipe(currentTask),
+      });
+    },
+    [tasks, updateTaskMutation],
+  );
+
+  const addTaskAction = useCallback(
+    async (input: AddTaskInput) => {
+      await createTaskMutation.mutateAsync({
         name: input.name,
-        categoryId: input.categoryId,
-        status: "todo" as TaskStatus,
-        isNext: false,
-        estimatedMinutes: input.estimatedMinutes,
+        categoryId: normalizeCategoryId(input.categoryId),
         scheduledDate: input.scheduledDate,
-        createdAt: now,
-        updatedAt: now,
-      };
-      setTasks((prev) => [...prev, newTask]);
+        estimatedMinutes: input.estimatedMinutes,
+      });
     },
-    [setTasks],
+    [createTaskMutation],
   );
 
-  const updateTask = useCallback(
-    (id: string, input: UpdateTaskInput) => {
-      const now = new Date().toISOString();
-      setTasks((prev) =>
-        prev.map((task) =>
-          task.id === id
-            ? {
-                ...task,
-                name: input.name,
-                categoryId: input.categoryId,
-                scheduledDate: input.scheduledDate,
-                estimatedMinutes: input.estimatedMinutes,
-                updatedAt: now,
-              }
-            : task,
-        ),
-      );
-    },
-    [setTasks],
-  );
-
-  const deleteTask = useCallback(
-    (id: string) => {
-      setTasks((prev) => prev.filter((task) => task.id !== id));
-    },
-    [setTasks],
-  );
-
-  const toggleComplete = useCallback(
-    (id: string) => {
-      const now = new Date().toISOString();
-      setTasks((prev) =>
-        prev.map((task) => {
-          if (task.id !== id) return task;
-          const newStatus: TaskStatus =
-            task.status === "done" ? "todo" : "done";
-          return {
-            ...task,
-            status: newStatus,
-            isNext: newStatus === "done" ? false : task.isNext,
-            updatedAt: now,
-          };
+  const updateTaskAction = useCallback(
+    async (id: string, input: UpdateTaskInput) => {
+      await mutateTask(id, (task) =>
+        toTaskMutationInput(task, {
+          name: input.name,
+          categoryId: input.categoryId,
+          scheduledDate: input.scheduledDate,
+          estimatedMinutes: input.estimatedMinutes,
         }),
       );
     },
-    [setTasks],
+    [mutateTask],
+  );
+
+  const deleteTaskAction = useCallback(
+    async (id: string) => {
+      await deleteTaskMutation.mutateAsync(id);
+    },
+    [deleteTaskMutation],
+  );
+
+  const toggleComplete = useCallback(
+    async (id: string) => {
+      await mutateTask(id, (task) => {
+        const nextStatus: TaskStatus = task.status === "done" ? "todo" : "done";
+        return toTaskMutationInput(task, {
+          status: nextStatus,
+          isNext: nextStatus === "done" ? false : task.isNext,
+        });
+      });
+    },
+    [mutateTask],
   );
 
   const setNextTask = useCallback(
-    (id: string) => {
-      const now = new Date().toISOString();
-      setTasks((prev) =>
-        prev.map((task) => ({
-          ...task,
-          isNext: task.id === id,
-          updatedAt: task.id === id || task.isNext ? now : task.updatedAt,
-        })),
+    async (id: string) => {
+      const currentTasks = tasks;
+      await Promise.all(
+        currentTasks
+          .filter((task) => task.id === id || task.isNext)
+          .map((task) =>
+            updateTaskMutation.mutateAsync({
+              id: task.id,
+              input: toTaskMutationInput(task, {
+                isNext: task.id === id,
+              }),
+            }),
+          ),
       );
     },
-    [setTasks],
+    [tasks, updateTaskMutation],
   );
 
   const unsetNextTask = useCallback(
-    (id: string) => {
-      const now = new Date().toISOString();
-      setTasks((prev) =>
-        prev.map((task) =>
-          task.id === id ? { ...task, isNext: false, updatedAt: now } : task,
-        ),
+    async (id: string) => {
+      await mutateTask(id, (task) =>
+        toTaskMutationInput(task, {
+          isNext: false,
+        }),
       );
     },
-    [setTasks],
+    [mutateTask],
   );
 
   const startWork = useCallback(
-    (id: string) => {
-      const now = new Date().toISOString();
-      setTasks((prev) =>
-        prev.map((task) =>
-          task.id === id
-            ? { ...task, status: "in_progress" as TaskStatus, updatedAt: now }
-            : task,
-        ),
+    async (id: string) => {
+      await mutateTask(id, (task) =>
+        toTaskMutationInput(task, {
+          status: "in_progress",
+        }),
       );
     },
-    [setTasks],
+    [mutateTask],
   );
 
   const completeTask = useCallback(
-    (id: string) => {
-      const now = new Date().toISOString();
-      setTasks((prev) =>
-        prev.map((task) =>
-          task.id === id
-            ? {
-                ...task,
-                status: "done" as TaskStatus,
-                isNext: false,
-                updatedAt: now,
-              }
-            : task,
-        ),
+    async (id: string) => {
+      await mutateTask(id, (task) =>
+        toTaskMutationInput(task, {
+          status: "done",
+          isNext: false,
+        }),
       );
     },
-    [setTasks],
+    [mutateTask],
   );
 
-  const addCategory = useCallback(
-    (name: string, color: string): string => {
-      const id = crypto.randomUUID();
-      const newCategory: Category = {
-        id,
+  const addCategoryAction = useCallback(
+    async (name: string, color: string) => {
+      const category = await createCategoryMutation.mutateAsync({
         name,
         color,
-      };
-      setCategories((prev) => [...prev, newCategory]);
-      return id;
+      });
+      return category.id;
     },
-    [setCategories],
+    [createCategoryMutation],
   );
 
-  const updateCategory = useCallback(
-    (id: string, name: string, color: string) => {
-      setCategories((prev) =>
-        prev.map((cat) => (cat.id === id ? { ...cat, name, color } : cat)),
-      );
+  const updateCategoryAction = useCallback(
+    async (id: string, name: string, color: string) => {
+      await updateCategoryMutation.mutateAsync({ id, name, color });
     },
-    [setCategories],
+    [updateCategoryMutation],
   );
 
-  const deleteCategory = useCallback(
-    (id: string) => {
-      setTasks((prev) =>
-        prev.map((task) =>
-          task.categoryId === id ? { ...task, categoryId: "" } : task,
-        ),
-      );
-      setCategories((prev) => prev.filter((cat) => cat.id !== id));
+  const deleteCategoryAction = useCallback(
+    async (id: string) => {
+      await deleteCategoryMutation.mutateAsync(id);
     },
-    [setTasks, setCategories],
+    [deleteCategoryMutation],
   );
 
   return {
     tasks: tasksWithCategory,
     categories,
-    addTask,
-    updateTask,
-    deleteTask,
+    addTask: addTaskAction,
+    updateTask: updateTaskAction,
+    deleteTask: deleteTaskAction,
     toggleComplete,
     setNextTask,
     unsetNextTask,
     startWork,
     completeTask,
-    addCategory,
-    updateCategory,
-    deleteCategory,
+    addCategory: addCategoryAction,
+    updateCategory: updateCategoryAction,
+    deleteCategory: deleteCategoryAction,
   };
 }

--- a/apps/web/src/shared/hooks/use-timer.ts
+++ b/apps/web/src/shared/hooks/use-timer.ts
@@ -2,11 +2,9 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { useLocalStorage } from "@/shared/hooks/use-local-storage";
-
+import { useCurrentTimerSession } from "@/shared/hooks/use-current-timer-session";
 import type { TimerSession } from "@/shared/types/timer";
 
-const TIMER_SESSION_KEY = "timer-session";
 const INTERVAL_MS = 1000;
 
 type UseTimerInput = {
@@ -20,10 +18,10 @@ type UseTimerReturn = {
   remainingSeconds: number;
   isRunning: boolean;
   isFinished: boolean;
-  start: () => void;
-  complete: () => TimerResult;
-  interrupt: () => TimerResult;
-  restart: () => void;
+  start: () => Promise<void>;
+  complete: () => Promise<TimerResult>;
+  interrupt: () => Promise<TimerResult>;
+  restart: () => Promise<void>;
 };
 
 export type TimerResult = {
@@ -31,6 +29,8 @@ export type TimerResult = {
   durationMinutes: number;
   startedAt: string;
 };
+
+export const TIMER_SESSION_KEY = "timer-session";
 
 function calcRemainingSeconds(
   startedAt: string,
@@ -41,24 +41,39 @@ function calcRemainingSeconds(
   return Math.max(0, remaining);
 }
 
+function getInitialState(
+  session: TimerSession | null,
+  estimatedMinutes: number,
+) {
+  const remainingSeconds = session
+    ? calcRemainingSeconds(session.startedAt, session.estimatedMinutes)
+    : estimatedMinutes * 60;
+  const isFinished = session !== null && remainingSeconds === 0;
+
+  return {
+    remainingSeconds,
+    isFinished,
+    isRunning: session !== null && !isFinished,
+  };
+}
+
 export function calcDurationMinutes(startedAt: string): number {
   return Math.floor((Date.now() - new Date(startedAt).getTime()) / 60000);
 }
 
-export function useTimer(input: UseTimerInput): UseTimerReturn {
-  const { value: session, setValue: setSession } =
-    useLocalStorage<TimerSession | null>(TIMER_SESSION_KEY, null);
+export function useTimer(
+  input: UseTimerInput,
+  initialSession?: TimerSession | null,
+): UseTimerReturn {
+  const { session, createSession, clearSession } =
+    useCurrentTimerSession(initialSession);
+  const initialState = getInitialState(session, input.estimatedMinutes);
 
-  const initialRemaining = session
-    ? calcRemainingSeconds(session.startedAt, session.estimatedMinutes)
-    : input.estimatedMinutes * 60;
-  const initialFinished = session !== null && initialRemaining === 0;
-
-  const [remainingSeconds, setRemainingSeconds] = useState(initialRemaining);
-  const [isRunning, setIsRunning] = useState(
-    () => session !== null && !initialFinished,
+  const [remainingSeconds, setRemainingSeconds] = useState(
+    initialState.remainingSeconds,
   );
-  const [isFinished, setIsFinished] = useState(initialFinished);
+  const [isRunning, setIsRunning] = useState(initialState.isRunning);
+  const [isFinished, setIsFinished] = useState(initialState.isFinished);
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -70,6 +85,13 @@ export function useTimer(input: UseTimerInput): UseTimerReturn {
   }, []);
 
   useEffect(() => {
+    const nextState = getInitialState(session, input.estimatedMinutes);
+    setRemainingSeconds(nextState.remainingSeconds);
+    setIsRunning(nextState.isRunning);
+    setIsFinished(nextState.isFinished);
+  }, [input.estimatedMinutes, session]);
+
+  useEffect(() => {
     if (!isRunning || isFinished || !session) return;
 
     const tick = () => {
@@ -78,60 +100,67 @@ export function useTimer(input: UseTimerInput): UseTimerReturn {
         session.estimatedMinutes,
       );
       setRemainingSeconds(remaining);
+
       if (remaining <= 0) {
         setIsFinished(true);
-        if (intervalRef.current !== null) {
-          clearInterval(intervalRef.current);
-          intervalRef.current = null;
-        }
+        clearTimer();
       }
     };
 
     intervalRef.current = setInterval(tick, INTERVAL_MS);
-    return () => {
-      if (intervalRef.current !== null) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    };
-  }, [isRunning, isFinished, session]);
+    return clearTimer;
+  }, [clearTimer, isFinished, isRunning, session]);
 
-  const initSession = useCallback(() => {
-    const now = new Date().toISOString();
-    const newSession: TimerSession = {
+  const start = useCallback(async () => {
+    const createdSession = await createSession({
       taskId: input.taskId,
       taskName: input.taskName,
       categoryName: input.categoryName,
       estimatedMinutes: input.estimatedMinutes,
-      startedAt: now,
-    };
-    setSession(newSession);
-    setRemainingSeconds(input.estimatedMinutes * 60);
+    });
+
+    setRemainingSeconds(
+      calcRemainingSeconds(
+        createdSession.startedAt,
+        createdSession.estimatedMinutes,
+      ),
+    );
     setIsFinished(false);
     setIsRunning(true);
-  }, [input, setSession]);
+  }, [createSession, input]);
 
-  const start = useCallback(() => initSession(), [initSession]);
+  const stop = useCallback(async (): Promise<TimerResult> => {
+    if (!session) {
+      throw new Error("No active timer session");
+    }
 
-  const stop = useCallback((): TimerResult => {
     clearTimer();
-    const currentSession = session!;
     const result: TimerResult = {
-      taskId: currentSession.taskId,
-      durationMinutes: calcDurationMinutes(currentSession.startedAt),
-      startedAt: currentSession.startedAt,
+      taskId: session.taskId,
+      durationMinutes: calcDurationMinutes(session.startedAt),
+      startedAt: session.startedAt,
     };
-    setSession(null);
+
+    await clearSession();
     setIsRunning(false);
     setIsFinished(false);
     return result;
-  }, [session, setSession, clearTimer]);
+  }, [clearSession, clearTimer, session]);
 
-  const complete = useCallback((): TimerResult => stop(), [stop]);
+  const complete = useCallback(async (): Promise<TimerResult> => {
+    return stop();
+  }, [stop]);
 
-  const interrupt = useCallback((): TimerResult => stop(), [stop]);
+  const interrupt = useCallback(async (): Promise<TimerResult> => {
+    return stop();
+  }, [stop]);
 
-  const restart = useCallback(() => initSession(), [initSession]);
+  const restart = useCallback(async () => {
+    if (session) {
+      await clearSession();
+    }
+    await start();
+  }, [clearSession, session, start]);
 
   return {
     remainingSeconds,
@@ -143,5 +172,3 @@ export function useTimer(input: UseTimerInput): UseTimerReturn {
     restart,
   };
 }
-
-export { TIMER_SESSION_KEY };

--- a/apps/web/src/shared/hooks/use-timer.ts
+++ b/apps/web/src/shared/hooks/use-timer.ts
@@ -30,8 +30,6 @@ export type TimerResult = {
   startedAt: string;
 };
 
-export const TIMER_SESSION_KEY = "timer-session";
-
 function calcRemainingSeconds(
   startedAt: string,
   estimatedMinutes: number,

--- a/apps/web/src/shared/hooks/use-work-records.ts
+++ b/apps/web/src/shared/hooks/use-work-records.ts
@@ -1,8 +1,10 @@
 "use client";
 
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import type { WorkResult } from "@/shared/enums/work-results";
-import { useLocalStorage } from "@/shared/hooks/use-local-storage";
+import { createWorkRecord, fetchWorkRecords } from "@/shared/lib/api";
+import { queryKeys } from "@/shared/lib/api/query-keys";
 import type { TaskWithCategory } from "@/shared/types/task";
 import type { WorkRecord } from "@/shared/types/work-record";
 
@@ -24,9 +26,13 @@ type AddWorkRecordInput = {
   result: WorkResult;
 };
 
+export type WorkRecordsInitialData = {
+  workRecords: WorkRecord[];
+};
+
 type UseWorkRecordsReturn = {
   recentWorkByDay: DayGroup[];
-  addWorkRecord: (input: AddWorkRecordInput) => void;
+  addWorkRecord: (input: AddWorkRecordInput) => Promise<void>;
   getWorkRecordsByMonth: (year: number, month: number) => WorkRecordWithTask[];
 };
 
@@ -34,10 +40,24 @@ const RECENT_DAYS_COUNT = 3;
 
 export function useWorkRecords(
   tasks: TaskWithCategory[],
+  initialData?: WorkRecordsInitialData,
 ): UseWorkRecordsReturn {
-  const { value: workRecords, setValue: setWorkRecords } = useLocalStorage<
-    WorkRecord[]
-  >("work-records", []);
+  const queryClient = useQueryClient();
+  const { data: workRecords = [] } = useQuery({
+    queryKey: queryKeys.workRecords,
+    queryFn: fetchWorkRecords,
+    initialData: initialData?.workRecords,
+  });
+
+  const createWorkRecordMutation = useMutation({
+    mutationFn: createWorkRecord,
+    onSuccess: (createdRecord) => {
+      queryClient.setQueryData<WorkRecord[]>(
+        queryKeys.workRecords,
+        (prev = []) => [...prev, createdRecord],
+      );
+    },
+  });
 
   const recentWorkByDay = useMemo(
     () => buildRecentWorkByDay(workRecords, tasks),
@@ -45,27 +65,20 @@ export function useWorkRecords(
   );
 
   const addWorkRecord = useCallback(
-    (input: AddWorkRecordInput) => {
-      const newRecord: WorkRecord = {
-        id: crypto.randomUUID(),
-        taskId: input.taskId,
-        date: input.date,
-        durationMinutes: input.durationMinutes,
-        result: input.result,
-      };
-      setWorkRecords((prev) => [...prev, newRecord]);
+    async (input: AddWorkRecordInput) => {
+      await createWorkRecordMutation.mutateAsync(input);
     },
-    [setWorkRecords],
+    [createWorkRecordMutation],
   );
 
   const getWorkRecordsByMonth = useCallback(
     (year: number, month: number): WorkRecordWithTask[] => {
       const prefix = `${year}-${String(month).padStart(2, "0")}`;
       return workRecords
-        .filter((r) => r.date.startsWith(prefix))
-        .map((r) => ({
-          ...r,
-          ...resolveTaskInfo(r.taskId, tasks),
+        .filter((record) => record.date.startsWith(prefix))
+        .map((record) => ({
+          ...record,
+          ...resolveTaskInfo(record.taskId, tasks),
         }));
     },
     [workRecords, tasks],
@@ -78,7 +91,7 @@ function resolveTaskInfo(
   taskId: string,
   tasks: TaskWithCategory[],
 ): { taskName: string; categoryName: string; categoryColor: string } {
-  const task = tasks.find((t) => t.id === taskId);
+  const task = tasks.find((candidate) => candidate.id === taskId);
   return {
     taskName: task?.name ?? "",
     categoryName: task?.category.name ?? "",
@@ -92,23 +105,21 @@ export function buildRecentWorkByDay(
 ): DayGroup[] {
   const byDate = new Map<string, WorkRecord[]>();
   for (const record of workRecords) {
-    const dateKey = record.date;
-    const existing = byDate.get(dateKey);
+    const existing = byDate.get(record.date);
     if (existing) {
       existing.push(record);
     } else {
-      byDate.set(dateKey, [record]);
+      byDate.set(record.date, [record]);
     }
   }
 
   const sortedDates = [...byDate.keys()].sort().reverse();
   const recentDates = sortedDates.slice(0, RECENT_DAYS_COUNT);
-
   const seenTaskIds = new Set<string>();
   const result: DayGroup[] = [];
 
   for (const date of recentDates) {
-    const dayRecords = byDate.get(date)!;
+    const dayRecords = byDate.get(date) ?? [];
     const uniqueRecords: WorkRecordWithTask[] = [];
 
     for (const record of [...dayRecords].reverse()) {

--- a/apps/web/src/shared/lib/api/client.ts
+++ b/apps/web/src/shared/lib/api/client.ts
@@ -1,0 +1,22 @@
+import type { AppType } from "@todo-list/api/client";
+import { hc } from "hono/client";
+
+function getApiBaseUrl() {
+  return (
+    process.env.API_URL ??
+    process.env.NEXT_PUBLIC_API_URL ??
+    "http://localhost:3001"
+  );
+}
+
+export function createApiClient() {
+  return hc<AppType>(getApiBaseUrl(), {
+    fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+      fetch(input, {
+        ...init,
+        cache: "no-store",
+      }),
+  });
+}
+
+export const apiClient = createApiClient();

--- a/apps/web/src/shared/lib/api/errors.ts
+++ b/apps/web/src/shared/lib/api/errors.ts
@@ -1,0 +1,34 @@
+export class ApiError extends Error {
+  status: number;
+  body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function readResponseBody(response: Response) {
+  const contentType = response.headers.get("content-type");
+  if (contentType?.includes("application/json")) {
+    return response.json();
+  }
+  return response.text();
+}
+
+export async function expectOk(
+  response: Response,
+  message: string,
+): Promise<Response> {
+  if (response.ok) {
+    return response;
+  }
+
+  throw new ApiError(
+    message,
+    response.status,
+    await readResponseBody(response),
+  );
+}

--- a/apps/web/src/shared/lib/api/index.ts
+++ b/apps/web/src/shared/lib/api/index.ts
@@ -1,0 +1,117 @@
+import { apiClient } from "./client";
+import { expectOk } from "./errors";
+import {
+  type CategoriesResponse,
+  type CreateCategoryRequest,
+  type CreateCategorySuccess,
+  type CreateTaskRequest,
+  type CreateTaskSuccess,
+  type CreateTimerSessionRequest,
+  type CreateTimerSessionSuccess,
+  type CreateWorkRecordRequest,
+  type CreateWorkRecordSuccess,
+  normalizeCategory,
+  normalizeTask,
+  normalizeTimerSession,
+  normalizeWorkRecord,
+  type TasksResponse,
+  type TimerSessionResponse,
+  type UpdateCategoryRequest,
+  type UpdateCategorySuccess,
+  type UpdateTaskRequest,
+  type UpdateTaskSuccess,
+  type WorkRecordsResponse,
+} from "./types";
+
+export async function fetchTasks() {
+  const response = await apiClient.tasks.$get();
+  await expectOk(response, "Failed to fetch tasks");
+  const tasks = (await response.json()) as TasksResponse;
+  return tasks.map(normalizeTask);
+}
+
+export async function createTask(input: CreateTaskRequest) {
+  const response = await apiClient.tasks.$post({ json: input });
+  await expectOk(response, "Failed to create task");
+  return normalizeTask((await response.json()) as CreateTaskSuccess);
+}
+
+export async function updateTask(id: string, input: UpdateTaskRequest) {
+  const response = await apiClient.tasks[":id"].$put({
+    param: { id },
+    json: input,
+  });
+  await expectOk(response, "Failed to update task");
+  return normalizeTask((await response.json()) as UpdateTaskSuccess);
+}
+
+export async function deleteTask(id: string) {
+  const response = await apiClient.tasks[":id"].$delete({
+    param: { id },
+  });
+  await expectOk(response, "Failed to delete task");
+}
+
+export async function fetchCategories() {
+  const response = await apiClient.categories.$get();
+  await expectOk(response, "Failed to fetch categories");
+  const categories = (await response.json()) as CategoriesResponse;
+  return categories.map(normalizeCategory);
+}
+
+export async function createCategory(input: CreateCategoryRequest) {
+  const response = await apiClient.categories.$post({ json: input });
+  await expectOk(response, "Failed to create category");
+  return normalizeCategory((await response.json()) as CreateCategorySuccess);
+}
+
+export async function updateCategory(id: string, input: UpdateCategoryRequest) {
+  const response = await apiClient.categories[":id"].$put({
+    param: { id },
+    json: input,
+  });
+  await expectOk(response, "Failed to update category");
+  return normalizeCategory((await response.json()) as UpdateCategorySuccess);
+}
+
+export async function deleteCategory(id: string) {
+  const response = await apiClient.categories[":id"].$delete({
+    param: { id },
+  });
+  await expectOk(response, "Failed to delete category");
+}
+
+export async function fetchWorkRecords() {
+  const response = await apiClient["work-records"].$get();
+  await expectOk(response, "Failed to fetch work records");
+  const records = (await response.json()) as WorkRecordsResponse;
+  return records.map(normalizeWorkRecord);
+}
+
+export async function createWorkRecord(input: CreateWorkRecordRequest) {
+  const response = await apiClient["work-records"].$post({ json: input });
+  await expectOk(response, "Failed to create work record");
+  return normalizeWorkRecord(
+    (await response.json()) as CreateWorkRecordSuccess,
+  );
+}
+
+export async function fetchCurrentTimerSession() {
+  const response = await apiClient["timer-sessions"].$get();
+  await expectOk(response, "Failed to fetch timer session");
+  const session = (await response.json()) as TimerSessionResponse;
+  return session ? normalizeTimerSession(session) : null;
+}
+
+export async function createTimerSession(input: CreateTimerSessionRequest) {
+  const response = await apiClient["timer-sessions"].$post({ json: input });
+  await expectOk(response, "Failed to create timer session");
+  return normalizeTimerSession(
+    (await response.json()) as CreateTimerSessionSuccess,
+  );
+}
+
+export async function deleteCurrentTimerSession() {
+  const response = await apiClient["timer-sessions"].$delete();
+  await expectOk(response, "Failed to delete timer session");
+}

--- a/apps/web/src/shared/lib/api/query-keys.ts
+++ b/apps/web/src/shared/lib/api/query-keys.ts
@@ -1,0 +1,6 @@
+export const queryKeys = {
+  categories: ["categories"] as const,
+  tasks: ["tasks"] as const,
+  timerSession: ["timer-session"] as const,
+  workRecords: ["work-records"] as const,
+};

--- a/apps/web/src/shared/lib/api/server.ts
+++ b/apps/web/src/shared/lib/api/server.ts
@@ -1,0 +1,13 @@
+import { cache } from "react";
+
+import {
+  fetchCategories,
+  fetchCurrentTimerSession,
+  fetchTasks,
+  fetchWorkRecords,
+} from "./index";
+
+export const getTasks = cache(fetchTasks);
+export const getCategories = cache(fetchCategories);
+export const getWorkRecords = cache(fetchWorkRecords);
+export const getCurrentTimerSession = cache(fetchCurrentTimerSession);

--- a/apps/web/src/shared/lib/api/types.ts
+++ b/apps/web/src/shared/lib/api/types.ts
@@ -1,0 +1,99 @@
+import type { AppType } from "@todo-list/api/client";
+import type { InferRequestType, InferResponseType } from "hono/client";
+import { hc } from "hono/client";
+
+import type { Category, Task } from "@/shared/types/task";
+import type { TimerSession } from "@/shared/types/timer";
+import type { WorkRecord } from "@/shared/types/work-record";
+
+const contractClient = hc<AppType>("http://localhost");
+
+export type TasksResponse = InferResponseType<
+  typeof contractClient.tasks.$get,
+  200
+>;
+export type TaskResponse = TasksResponse[number];
+export type CreateTaskSuccess = InferResponseType<
+  typeof contractClient.tasks.$post,
+  201
+>;
+export type UpdateTaskSuccess = InferResponseType<
+  (typeof contractClient.tasks)[":id"]["$put"],
+  200
+>;
+export type CategoriesResponse = InferResponseType<
+  typeof contractClient.categories.$get,
+  200
+>;
+export type CategoryResponse = CategoriesResponse[number];
+export type CreateCategorySuccess = InferResponseType<
+  typeof contractClient.categories.$post,
+  201
+>;
+export type UpdateCategorySuccess = InferResponseType<
+  (typeof contractClient.categories)[":id"]["$put"],
+  200
+>;
+export type WorkRecordsResponse = InferResponseType<
+  (typeof contractClient)["work-records"]["$get"],
+  200
+>;
+export type WorkRecordResponse = WorkRecordsResponse[number];
+export type CreateWorkRecordSuccess = InferResponseType<
+  (typeof contractClient)["work-records"]["$post"],
+  201
+>;
+export type TimerSessionResponse = InferResponseType<
+  (typeof contractClient)["timer-sessions"]["$get"],
+  200
+>;
+export type CreateTimerSessionSuccess = InferResponseType<
+  (typeof contractClient)["timer-sessions"]["$post"],
+  201
+>;
+
+export type CreateTaskRequest = InferRequestType<
+  typeof contractClient.tasks.$post
+>["json"];
+export type UpdateTaskRequest = InferRequestType<
+  (typeof contractClient.tasks)[":id"]["$put"]
+>["json"];
+export type CreateCategoryRequest = InferRequestType<
+  typeof contractClient.categories.$post
+>["json"];
+export type UpdateCategoryRequest = InferRequestType<
+  (typeof contractClient.categories)[":id"]["$put"]
+>["json"];
+export type CreateWorkRecordRequest = InferRequestType<
+  (typeof contractClient)["work-records"]["$post"]
+>["json"];
+export type CreateTimerSessionRequest = InferRequestType<
+  (typeof contractClient)["timer-sessions"]["$post"]
+>["json"];
+
+export function normalizeTask(task: TaskResponse): Task {
+  return {
+    ...task,
+    categoryId: task.categoryId ?? "",
+  };
+}
+
+export function normalizeCategory(category: CategoryResponse): Category {
+  return category;
+}
+
+export function normalizeWorkRecord(record: WorkRecordResponse): WorkRecord {
+  return record;
+}
+
+export function normalizeTimerSession(
+  session: Exclude<TimerSessionResponse, null>,
+): TimerSession {
+  return {
+    taskId: session.taskId,
+    taskName: session.taskName,
+    categoryName: session.categoryName,
+    estimatedMinutes: session.estimatedMinutes,
+    startedAt: session.startedAt,
+  };
+}

--- a/apps/web/src/shared/providers/query-provider.tsx
+++ b/apps/web/src/shared/providers/query-provider.tsx
@@ -10,6 +10,7 @@ export function AppQueryProvider({ children }: { children: React.ReactNode }) {
         defaultOptions: {
           queries: {
             retry: false,
+            staleTime: 30_000,
           },
         },
       }),

--- a/apps/web/src/shared/providers/query-provider.tsx
+++ b/apps/web/src/shared/providers/query-provider.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function AppQueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/apps/web/src/shared/ui/add-task-form.tsx
+++ b/apps/web/src/shared/ui/add-task-form.tsx
@@ -29,8 +29,8 @@ const ESTIMATED_MINUTES_OPTIONS = [
 
 interface AddTaskFormProps {
   onClose: () => void;
-  onSubmit: (data: TaskFormData) => void;
-  onCreateCategory: (name: string, color: string) => string;
+  onSubmit: (data: TaskFormData) => Promise<void>;
+  onCreateCategory: (name: string, color: string) => Promise<string>;
   categories: Category[];
   editingTask?: TaskFormData & { id: string };
 }
@@ -54,13 +54,13 @@ export function AddTaskForm({
   );
   const [nameError, setNameError] = useState(false);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!name.trim()) {
       setNameError(true);
       return;
     }
 
-    onSubmit({
+    await onSubmit({
       name: name.trim(),
       categoryId,
       scheduledDate: scheduledDate ? format(scheduledDate, "yyyy-MM-dd") : null,

--- a/apps/web/src/shared/ui/add-task-modal.tsx
+++ b/apps/web/src/shared/ui/add-task-modal.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import type { Category } from "@/shared/types/task";
-import { Dialog, DialogContent } from "@/shared/ui/shadcn/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+} from "@/shared/ui/shadcn/dialog";
 import { AddTaskForm } from "./add-task-form";
 
 export interface TaskFormData {
@@ -14,8 +18,8 @@ export interface TaskFormData {
 interface AddTaskModalProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (data: TaskFormData) => void;
-  onCreateCategory: (name: string, color: string) => string;
+  onSubmit: (data: TaskFormData) => Promise<void>;
+  onCreateCategory: (name: string, color: string) => Promise<string>;
   categories: Category[];
   editingTask?: TaskFormData & { id: string };
 }
@@ -31,6 +35,9 @@ export function AddTaskModal({
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent showCloseButton={false} className="sm:max-w-md">
+        <DialogDescription className="sr-only">
+          タスク名、カテゴリ、予定日、見積もり時間を入力するダイアログです。
+        </DialogDescription>
         <AddTaskForm
           key={editingTask?.id ?? "new"}
           onClose={onClose}

--- a/apps/web/src/shared/ui/category-select.tsx
+++ b/apps/web/src/shared/ui/category-select.tsx
@@ -15,7 +15,7 @@ interface CategorySelectProps {
   categories: Category[];
   selectedCategoryId: string;
   onSelect: (categoryId: string) => void;
-  onCreateCategory: (name: string, color: string) => string;
+  onCreateCategory: (name: string, color: string) => Promise<string>;
   className?: string;
 }
 
@@ -38,9 +38,9 @@ export function CategorySelect({
     setIsOpen(false);
   };
 
-  const handleCreateCategory = () => {
+  const handleCreateCategory = async () => {
     if (!newCategoryName.trim()) return;
-    const newId = onCreateCategory(newCategoryName.trim(), selectedColor);
+    const newId = await onCreateCategory(newCategoryName.trim(), selectedColor);
     onSelect(newId);
     setNewCategoryName("");
     setSelectedColor(CATEGORY_COLORS[0]);

--- a/apps/web/src/shared/ui/recovery-dialog-provider.tsx
+++ b/apps/web/src/shared/ui/recovery-dialog-provider.tsx
@@ -3,52 +3,60 @@
 import { format } from "date-fns";
 import { useCallback } from "react";
 
-import { useLocalStorage } from "@/shared/hooks/use-local-storage";
+import { useCurrentTimerSession } from "@/shared/hooks/use-current-timer-session";
 import { useTasks } from "@/shared/hooks/use-tasks";
-import {
-  calcDurationMinutes,
-  TIMER_SESSION_KEY,
-} from "@/shared/hooks/use-timer";
+import { calcDurationMinutes } from "@/shared/hooks/use-timer";
 import { useWorkRecords } from "@/shared/hooks/use-work-records";
 import type { TimerSession } from "@/shared/types/timer";
 import { RecoveryDialog } from "@/shared/ui/recovery-dialog";
 
-export function RecoveryDialogProvider() {
+export function RecoveryDialogProvider({
+  initialSession,
+}: {
+  initialSession: TimerSession | null;
+}) {
+  const { session, clearSession } = useCurrentTimerSession(initialSession);
   const { tasks, completeTask } = useTasks();
   const { addWorkRecord } = useWorkRecords(tasks);
-  const { setValue: setSession } = useLocalStorage<TimerSession | null>(
-    TIMER_SESSION_KEY,
-    null,
-  );
 
   const handleComplete = useCallback(
-    (session: TimerSession) => {
-      completeTask(session.taskId);
-      addWorkRecord({
-        taskId: session.taskId,
-        date: format(new Date(session.startedAt), "yyyy-MM-dd"),
-        durationMinutes: Math.max(1, calcDurationMinutes(session.startedAt)),
+    async (activeSession: TimerSession) => {
+      await completeTask(activeSession.taskId);
+      await addWorkRecord({
+        taskId: activeSession.taskId,
+        date: format(new Date(activeSession.startedAt), "yyyy-MM-dd"),
+        durationMinutes: Math.max(
+          1,
+          calcDurationMinutes(activeSession.startedAt),
+        ),
         result: "completed",
       });
-      setSession(null);
+      await clearSession();
     },
-    [completeTask, addWorkRecord, setSession],
+    [addWorkRecord, clearSession, completeTask],
   );
 
   const handleInterrupt = useCallback(
-    (session: TimerSession) => {
-      addWorkRecord({
-        taskId: session.taskId,
-        date: format(new Date(session.startedAt), "yyyy-MM-dd"),
-        durationMinutes: Math.max(1, calcDurationMinutes(session.startedAt)),
+    async (activeSession: TimerSession) => {
+      await addWorkRecord({
+        taskId: activeSession.taskId,
+        date: format(new Date(activeSession.startedAt), "yyyy-MM-dd"),
+        durationMinutes: Math.max(
+          1,
+          calcDurationMinutes(activeSession.startedAt),
+        ),
         result: "interrupted",
       });
-      setSession(null);
+      await clearSession();
     },
-    [addWorkRecord, setSession],
+    [addWorkRecord, clearSession],
   );
 
   return (
-    <RecoveryDialog onComplete={handleComplete} onInterrupt={handleInterrupt} />
+    <RecoveryDialog
+      session={session}
+      onComplete={handleComplete}
+      onInterrupt={handleInterrupt}
+    />
   );
 }

--- a/apps/web/src/shared/ui/recovery-dialog-provider.tsx
+++ b/apps/web/src/shared/ui/recovery-dialog-provider.tsx
@@ -1,13 +1,16 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { useCallback } from "react";
 
 import { useCurrentTimerSession } from "@/shared/hooks/use-current-timer-session";
-import { useTasks } from "@/shared/hooks/use-tasks";
 import { calcDurationMinutes } from "@/shared/hooks/use-timer";
-import { useWorkRecords } from "@/shared/hooks/use-work-records";
+import { createWorkRecord, fetchTasks, updateTask } from "@/shared/lib/api";
+import { queryKeys } from "@/shared/lib/api/query-keys";
+import type { Task } from "@/shared/types/task";
 import type { TimerSession } from "@/shared/types/timer";
+import type { WorkRecord } from "@/shared/types/work-record";
 import { RecoveryDialog } from "@/shared/ui/recovery-dialog";
 
 export function RecoveryDialogProvider({
@@ -15,14 +18,35 @@ export function RecoveryDialogProvider({
 }: {
   initialSession: TimerSession | null;
 }) {
+  const queryClient = useQueryClient();
   const { session, clearSession } = useCurrentTimerSession(initialSession);
-  const { tasks, completeTask } = useTasks();
-  const { addWorkRecord } = useWorkRecords(tasks);
 
   const handleComplete = useCallback(
     async (activeSession: TimerSession) => {
-      await completeTask(activeSession.taskId);
-      await addWorkRecord({
+      const tasks = await fetchTasks();
+      const currentTask = tasks.find(
+        (task) => task.id === activeSession.taskId,
+      );
+      if (!currentTask) {
+        throw new Error("Task not found for recovery session");
+      }
+
+      const completedTask = await updateTask(activeSession.taskId, {
+        name: currentTask.name,
+        categoryId:
+          currentTask.categoryId === "" ? null : currentTask.categoryId,
+        status: "done",
+        isNext: false,
+        estimatedMinutes: currentTask.estimatedMinutes,
+        scheduledDate: currentTask.scheduledDate,
+      });
+      queryClient.setQueryData<Task[]>(queryKeys.tasks, (prev = tasks) =>
+        prev.map((task) =>
+          task.id === completedTask.id ? completedTask : task,
+        ),
+      );
+
+      const createdRecord = await createWorkRecord({
         taskId: activeSession.taskId,
         date: format(new Date(activeSession.startedAt), "yyyy-MM-dd"),
         durationMinutes: Math.max(
@@ -31,14 +55,18 @@ export function RecoveryDialogProvider({
         ),
         result: "completed",
       });
+      queryClient.setQueryData<WorkRecord[]>(
+        queryKeys.workRecords,
+        (prev = []) => [...prev, createdRecord],
+      );
       await clearSession();
     },
-    [addWorkRecord, clearSession, completeTask],
+    [clearSession, queryClient],
   );
 
   const handleInterrupt = useCallback(
     async (activeSession: TimerSession) => {
-      await addWorkRecord({
+      const createdRecord = await createWorkRecord({
         taskId: activeSession.taskId,
         date: format(new Date(activeSession.startedAt), "yyyy-MM-dd"),
         durationMinutes: Math.max(
@@ -47,9 +75,13 @@ export function RecoveryDialogProvider({
         ),
         result: "interrupted",
       });
+      queryClient.setQueryData<WorkRecord[]>(
+        queryKeys.workRecords,
+        (prev = []) => [...prev, createdRecord],
+      );
       await clearSession();
     },
-    [addWorkRecord, clearSession],
+    [clearSession, queryClient],
   );
 
   return (

--- a/apps/web/src/shared/ui/recovery-dialog.tsx
+++ b/apps/web/src/shared/ui/recovery-dialog.tsx
@@ -4,8 +4,6 @@ import { Check, CircleAlert, Pause } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 
-import { useLocalStorage } from "@/shared/hooks/use-local-storage";
-import { TIMER_SESSION_KEY } from "@/shared/hooks/use-timer";
 import type { TimerSession } from "@/shared/types/timer";
 import { Button } from "@/shared/ui/shadcn/button";
 import {
@@ -17,33 +15,31 @@ import {
 } from "@/shared/ui/shadcn/dialog";
 
 export function RecoveryDialog({
+  session,
   onComplete,
   onInterrupt,
 }: {
-  onComplete: (session: TimerSession) => void;
-  onInterrupt: (session: TimerSession) => void;
+  session: TimerSession | null;
+  onComplete: (session: TimerSession) => Promise<void>;
+  onInterrupt: (session: TimerSession) => Promise<void>;
 }) {
   const pathname = usePathname();
   const router = useRouter();
-  const { value: session } = useLocalStorage<TimerSession | null>(
-    TIMER_SESSION_KEY,
-    null,
-  );
   const [dismissed, setDismissed] = useState(false);
 
   const shouldShow = session !== null && pathname !== "/timer" && !dismissed;
 
   if (!shouldShow || !session) return null;
 
-  const handleComplete = () => {
+  const handleComplete = async () => {
     setDismissed(true);
-    onComplete(session);
+    await onComplete(session);
     router.push("/");
   };
 
-  const handleInterrupt = () => {
+  const handleInterrupt = async () => {
     setDismissed(true);
-    onInterrupt(session);
+    await onInterrupt(session);
     router.push("/");
   };
 

--- a/apps/web/src/views/calendar/ui/calendar-page.tsx
+++ b/apps/web/src/views/calendar/ui/calendar-page.tsx
@@ -11,8 +11,13 @@ import {
 import { useRouter } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 
-import { useTasks } from "@/shared/hooks/use-tasks";
-import { useWorkRecords } from "@/shared/hooks/use-work-records";
+import { type TasksInitialData, useTasks } from "@/shared/hooks/use-tasks";
+import {
+  useWorkRecords,
+  type WorkRecordsInitialData,
+} from "@/shared/hooks/use-work-records";
+import type { Category, Task } from "@/shared/types/task";
+import type { WorkRecord } from "@/shared/types/work-record";
 import { SectionHeader } from "@/shared/ui/section-header";
 import { Sidebar } from "@/shared/ui/sidebar";
 import { TabBar } from "@/shared/ui/tab-bar";
@@ -21,10 +26,25 @@ import { CalendarGrid } from "./calendar-grid";
 import { CalendarTaskItem } from "./calendar-task-item";
 import { MonthNavigator } from "./month-navigator";
 
-export function CalendarPage() {
+type CalendarPageProps = {
+  initialTasks: Task[];
+  initialCategories: Category[];
+  initialWorkRecords: WorkRecord[];
+};
+
+export function CalendarPage({
+  initialTasks,
+  initialCategories,
+  initialWorkRecords,
+}: CalendarPageProps) {
   const router = useRouter();
-  const { tasks } = useTasks();
-  const { getWorkRecordsByMonth } = useWorkRecords(tasks);
+  const { tasks } = useTasks({
+    tasks: initialTasks,
+    categories: initialCategories,
+  } satisfies TasksInitialData);
+  const { getWorkRecordsByMonth } = useWorkRecords(tasks, {
+    workRecords: initialWorkRecords,
+  } satisfies WorkRecordsInitialData);
 
   const [currentMonth, setCurrentMonth] = useState(() =>
     startOfMonth(new Date()),

--- a/apps/web/src/views/home/ui/home-page.tsx
+++ b/apps/web/src/views/home/ui/home-page.tsx
@@ -5,8 +5,13 @@ import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 
 import { useTaskPageActions } from "@/shared/hooks/use-task-page-actions";
-import { useTasks } from "@/shared/hooks/use-tasks";
-import { useWorkRecords } from "@/shared/hooks/use-work-records";
+import { type TasksInitialData, useTasks } from "@/shared/hooks/use-tasks";
+import {
+  useWorkRecords,
+  type WorkRecordsInitialData,
+} from "@/shared/hooks/use-work-records";
+import type { Category, Task } from "@/shared/types/task";
+import type { WorkRecord } from "@/shared/types/work-record";
 import { AddTaskModal } from "@/shared/ui/add-task-modal";
 import { DeleteConfirmDialog } from "@/shared/ui/delete-confirm-dialog";
 import { EmptyState } from "@/shared/ui/empty-state";
@@ -16,7 +21,17 @@ import { RecentWorkColumn } from "./recent-work-column";
 import { TaskContent } from "./task-content";
 import { TopRow } from "./top-row";
 
-export function HomePage() {
+type HomePageProps = {
+  initialTasks: Task[];
+  initialCategories: Category[];
+  initialWorkRecords: WorkRecord[];
+};
+
+export function HomePage({
+  initialTasks,
+  initialCategories,
+  initialWorkRecords,
+}: HomePageProps) {
   const router = useRouter();
   const {
     tasks,
@@ -27,9 +42,14 @@ export function HomePage() {
     setNextTask,
     unsetNextTask,
     addCategory,
-  } = useTasks();
+  } = useTasks({
+    tasks: initialTasks,
+    categories: initialCategories,
+  } satisfies TasksInitialData);
 
-  const { recentWorkByDay } = useWorkRecords(tasks);
+  const { recentWorkByDay } = useWorkRecords(tasks, {
+    workRecords: initialWorkRecords,
+  } satisfies WorkRecordsInitialData);
 
   const {
     expandedTaskId,

--- a/apps/web/src/views/settings/ui/category-form.tsx
+++ b/apps/web/src/views/settings/ui/category-form.tsx
@@ -10,7 +10,7 @@ import { Input } from "@/shared/ui/shadcn/input";
 
 interface CategoryFormProps {
   editingCategory: Category | null;
-  onSubmit: (name: string, color: string) => void;
+  onSubmit: (name: string, color: string) => Promise<void>;
   onCancel: () => void;
 }
 
@@ -28,10 +28,10 @@ export function CategoryForm({
   const title = isEditing ? "カテゴリ編集" : "カテゴリ追加";
   const submitLabel = isEditing ? "保存" : "追加";
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const trimmed = name.trim();
     if (!trimmed) return;
-    onSubmit(trimmed, color);
+    await onSubmit(trimmed, color);
   };
 
   return (

--- a/apps/web/src/views/settings/ui/settings-page.tsx
+++ b/apps/web/src/views/settings/ui/settings-page.tsx
@@ -4,10 +4,15 @@ import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 
 import { useMediaQuery } from "@/shared/hooks/use-media-query";
-import { useTasks } from "@/shared/hooks/use-tasks";
-import type { Category } from "@/shared/types/task";
+import { type TasksInitialData, useTasks } from "@/shared/hooks/use-tasks";
+import type { Category, Task } from "@/shared/types/task";
 import { SectionHeader } from "@/shared/ui/section-header";
-import { Dialog, DialogContent } from "@/shared/ui/shadcn/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/shared/ui/shadcn/dialog";
 import { Sidebar } from "@/shared/ui/sidebar";
 import { TabBar } from "@/shared/ui/tab-bar";
 import { CategoryDeleteDialog } from "./category-delete-dialog";
@@ -19,10 +24,21 @@ type FormState =
   | { mode: "add" }
   | { mode: "edit"; category: Category };
 
-export function SettingsPage() {
+type SettingsPageProps = {
+  initialTasks: Task[];
+  initialCategories: Category[];
+};
+
+export function SettingsPage({
+  initialTasks,
+  initialCategories,
+}: SettingsPageProps) {
   const router = useRouter();
   const { tasks, categories, addCategory, updateCategory, deleteCategory } =
-    useTasks();
+    useTasks({
+      tasks: initialTasks,
+      categories: initialCategories,
+    } satisfies TasksInitialData);
 
   const [formState, setFormState] = useState<FormState>({ mode: "closed" });
   const [deleteTarget, setDeleteTarget] = useState<Category | null>(null);
@@ -50,32 +66,32 @@ export function SettingsPage() {
   }, []);
 
   const handleDelete = useCallback(
-    (category: Category) => {
+    async (category: Category) => {
       const hasLinkedTasks = tasks.some(
         (task) => task.categoryId === category.id,
       );
       if (hasLinkedTasks) {
         setDeleteTarget(category);
       } else {
-        deleteCategory(category.id);
+        await deleteCategory(category.id);
       }
     },
     [tasks, deleteCategory],
   );
 
-  const handleConfirmDelete = useCallback(() => {
+  const handleConfirmDelete = useCallback(async () => {
     if (!deleteTarget) return;
-    deleteCategory(deleteTarget.id);
+    await deleteCategory(deleteTarget.id);
     setDeleteTarget(null);
     setFormState({ mode: "closed" });
   }, [deleteTarget, deleteCategory]);
 
   const handleFormSubmit = useCallback(
-    (name: string, color: string) => {
+    async (name: string, color: string) => {
       if (formState.mode === "add") {
-        addCategory(name, color);
+        await addCategory(name, color);
       } else if (formState.mode === "edit") {
-        updateCategory(formState.category.id, name, color);
+        await updateCategory(formState.category.id, name, color);
       }
       setFormState({ mode: "closed" });
     },
@@ -134,6 +150,12 @@ export function SettingsPage() {
                 showCloseButton={false}
                 className="block border-none bg-transparent p-0 shadow-none"
               >
+                <DialogTitle className="sr-only">
+                  {editingCategory ? "カテゴリ編集" : "カテゴリ追加"}
+                </DialogTitle>
+                <DialogDescription className="sr-only">
+                  カテゴリ名とカラーを入力して保存するダイアログです。
+                </DialogDescription>
                 <CategoryForm
                   key={
                     formState.mode === "edit"

--- a/apps/web/src/views/tasks/ui/tasks-page.tsx
+++ b/apps/web/src/views/tasks/ui/tasks-page.tsx
@@ -4,8 +4,9 @@ import { Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { useTaskPageActions } from "@/shared/hooks/use-task-page-actions";
-import { useTasks } from "@/shared/hooks/use-tasks";
+import { type TasksInitialData, useTasks } from "@/shared/hooks/use-tasks";
 import { formatDuration } from "@/shared/lib/format-duration";
+import type { Category, Task } from "@/shared/types/task";
 import { AddTaskModal } from "@/shared/ui/add-task-modal";
 import { DeleteConfirmDialog } from "@/shared/ui/delete-confirm-dialog";
 import { EmptyState } from "@/shared/ui/empty-state";
@@ -25,7 +26,12 @@ const STATUS_FILTERS: { key: StatusFilter; label: string }[] = [
   { key: "done", label: "完了済み" },
 ];
 
-export function TasksPage() {
+type TasksPageProps = {
+  initialTasks: Task[];
+  initialCategories: Category[];
+};
+
+export function TasksPage({ initialTasks, initialCategories }: TasksPageProps) {
   const {
     tasks,
     categories,
@@ -35,7 +41,10 @@ export function TasksPage() {
     setNextTask,
     unsetNextTask,
     addCategory,
-  } = useTasks();
+  } = useTasks({
+    tasks: initialTasks,
+    categories: initialCategories,
+  } satisfies TasksInitialData);
 
   const {
     expandedTaskId,

--- a/apps/web/src/views/timer/ui/timer-page-content.tsx
+++ b/apps/web/src/views/timer/ui/timer-page-content.tsx
@@ -3,12 +3,18 @@
 import { format } from "date-fns";
 import { Check, Pause } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
-import { useTasks } from "@/shared/hooks/use-tasks";
+import { type TasksInitialData, useTasks } from "@/shared/hooks/use-tasks";
 import type { TimerResult } from "@/shared/hooks/use-timer";
 import { useTimer } from "@/shared/hooks/use-timer";
-import { useWorkRecords } from "@/shared/hooks/use-work-records";
+import {
+  useWorkRecords,
+  type WorkRecordsInitialData,
+} from "@/shared/hooks/use-work-records";
+import type { Category, Task } from "@/shared/types/task";
+import type { TimerSession } from "@/shared/types/timer";
+import type { WorkRecord } from "@/shared/types/work-record";
 import { Badge } from "@/shared/ui/shadcn/badge";
 import { Button } from "@/shared/ui/shadcn/button";
 import { Sidebar } from "@/shared/ui/sidebar";
@@ -18,13 +24,31 @@ import { TimerRing } from "./timer-ring";
 
 const DEFAULT_MINUTES = 60;
 
-export function TimerPageContent() {
+type TimerPageContentProps = {
+  initialTasks: Task[];
+  initialCategories: Category[];
+  initialWorkRecords?: WorkRecord[];
+  initialTimerSession: TimerSession | null;
+};
+
+export function TimerPageContent({
+  initialTasks,
+  initialCategories,
+  initialWorkRecords,
+  initialTimerSession,
+}: TimerPageContentProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const taskId = searchParams.get("taskId");
+  const hasStartedRef = useRef(false);
 
-  const { tasks, startWork, completeTask } = useTasks();
-  const { addWorkRecord } = useWorkRecords(tasks);
+  const { tasks, startWork, completeTask } = useTasks({
+    tasks: initialTasks,
+    categories: initialCategories,
+  } satisfies TasksInitialData);
+  const { addWorkRecord } = useWorkRecords(tasks, {
+    workRecords: initialWorkRecords ?? [],
+  } satisfies WorkRecordsInitialData);
 
   const task = useMemo(
     () => tasks.find((t) => t.id === taskId),
@@ -33,22 +57,34 @@ export function TimerPageContent() {
 
   const estimatedMinutes = task?.estimatedMinutes ?? DEFAULT_MINUTES;
 
-  const timer = useTimer({
-    taskId: taskId ?? "",
-    taskName: task?.name ?? "",
-    categoryName: task?.category.name ?? "",
-    estimatedMinutes,
-  });
+  const timer = useTimer(
+    {
+      taskId: taskId ?? "",
+      taskName: task?.name ?? "",
+      categoryName: task?.category.name ?? "",
+      estimatedMinutes,
+    },
+    initialTimerSession,
+  );
 
   useEffect(() => {
-    if (!taskId) return;
-    if (!timer.isRunning && !timer.isFinished) {
-      if (task) {
-        startWork(taskId);
-      }
-      timer.start();
+    if (
+      !taskId ||
+      !task ||
+      timer.isRunning ||
+      timer.isFinished ||
+      hasStartedRef.current
+    ) {
+      return;
     }
-  }, [taskId]); // oxlint-disable-line react-hooks/exhaustive-deps -- taskId 変更時のみ実行（timer/task/startWork は初回起動の制御に使うため deps から除外）
+
+    hasStartedRef.current = true;
+
+    void (async () => {
+      await startWork(taskId);
+      await timer.start();
+    })();
+  }, [startWork, task, taskId, timer]);
 
   const handleNavChange = useCallback(
     (key: string) => {
@@ -65,8 +101,8 @@ export function TimerPageContent() {
   );
 
   const recordWork = useCallback(
-    (result: TimerResult, workResult: "completed" | "interrupted") => {
-      addWorkRecord({
+    async (result: TimerResult, workResult: "completed" | "interrupted") => {
+      await addWorkRecord({
         taskId: result.taskId,
         date: format(new Date(result.startedAt), "yyyy-MM-dd"),
         durationMinutes: Math.max(1, result.durationMinutes),
@@ -76,21 +112,23 @@ export function TimerPageContent() {
     [addWorkRecord],
   );
 
-  const handleComplete = useCallback(() => {
-    const result = timer.complete();
-    if (taskId) completeTask(taskId);
-    recordWork(result, "completed");
+  const handleComplete = useCallback(async () => {
+    const result = await timer.complete();
+    if (taskId) {
+      await completeTask(taskId);
+    }
+    await recordWork(result, "completed");
     router.push("/");
   }, [timer, taskId, completeTask, recordWork, router]);
 
-  const handleInterrupt = useCallback(() => {
-    const result = timer.interrupt();
-    recordWork(result, "interrupted");
+  const handleInterrupt = useCallback(async () => {
+    const result = await timer.interrupt();
+    await recordWork(result, "interrupted");
     router.push("/");
   }, [timer, recordWork, router]);
 
-  const handleContinue = useCallback(() => {
-    timer.restart();
+  const handleContinue = useCallback(async () => {
+    await timer.restart();
   }, [timer]);
 
   if (!taskId) {

--- a/apps/web/src/views/timer/ui/timer-page-content.tsx
+++ b/apps/web/src/views/timer/ui/timer-page-content.tsx
@@ -40,7 +40,7 @@ export function TimerPageContent({
   const router = useRouter();
   const searchParams = useSearchParams();
   const taskId = searchParams.get("taskId");
-  const hasStartedRef = useRef(false);
+  const startedTaskIdRef = useRef<string | null>(null);
 
   const { tasks, startWork, completeTask } = useTasks({
     tasks: initialTasks,
@@ -73,16 +73,22 @@ export function TimerPageContent({
       !task ||
       timer.isRunning ||
       timer.isFinished ||
-      hasStartedRef.current
+      startedTaskIdRef.current === taskId
     ) {
       return;
     }
 
-    hasStartedRef.current = true;
+    startedTaskIdRef.current = taskId;
 
     void (async () => {
-      await startWork(taskId);
-      await timer.start();
+      try {
+        await startWork(taskId);
+        await timer.start();
+      } catch {
+        if (startedTaskIdRef.current === taskId) {
+          startedTaskIdRef.current = null;
+        }
+      }
     })();
   }, [startWork, task, taskId, timer]);
 

--- a/apps/web/src/views/timer/ui/timer-page.tsx
+++ b/apps/web/src/views/timer/ui/timer-page.tsx
@@ -1,13 +1,28 @@
 "use client";
 
 import { Suspense } from "react";
-
+import type { Category, Task } from "@/shared/types/task";
+import type { TimerSession } from "@/shared/types/timer";
 import { TimerPageContent } from "./timer-page-content";
 
-export function TimerPage() {
+type TimerPageProps = {
+  initialTasks: Task[];
+  initialCategories: Category[];
+  initialTimerSession: TimerSession | null;
+};
+
+export function TimerPage({
+  initialTasks,
+  initialCategories,
+  initialTimerSession,
+}: TimerPageProps) {
   return (
     <Suspense>
-      <TimerPageContent />
+      <TimerPageContent
+        initialTasks={initialTasks}
+        initialCategories={initialCategories}
+        initialTimerSession={initialTimerSession}
+      />
     </Suspense>
   );
 }

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -1,6 +1,5 @@
-import path from "path";
-
 import react from "@vitejs/plugin-react";
+import path from "path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,11 @@
   "files": {
     "includes": [
       "**",
+      "!**/.claude",
+      "!**/.claude/**",
       "!**/.next",
+      "!**/.pnpm-store",
+      "!**/.pnpm-store/**",
       "!**/node_modules",
       "!**/pnpm-lock.yaml",
       "!**/shared/ui/shadcn/**"

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,4 +1,3 @@
-export { type IdParam, idParamSchema } from "./common";
 export {
   type CategoryResponse,
   type CreateCategoryInput,
@@ -7,6 +6,7 @@ export {
   type UpdateCategoryInput,
   updateCategorySchema,
 } from "./category";
+export { type IdParam, idParamSchema } from "./common";
 export {
   type CreateTaskInput,
   createTaskSchema,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.99.0(react@19.2.5)
+      '@todo-list/api':
+        specifier: workspace:*
+        version: link:../api
+      '@todo-list/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -69,6 +78,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      hono:
+        specifier: ^4.7.0
+        version: 4.12.14
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.5)
@@ -2054,6 +2066,14 @@ packages:
 
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
+
+  '@tanstack/query-core@5.99.0':
+    resolution: {integrity: sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==}
+
+  '@tanstack/react-query@5.99.0':
+    resolution: {integrity: sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5884,6 +5904,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.2
       postcss: 8.5.10
       tailwindcss: 4.2.2
+
+  '@tanstack/query-core@5.99.0': {}
+
+  '@tanstack/react-query@5.99.0(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.99.0
+      react: 19.2.5
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## 概要
- フロントエンドのデータ取得を localStorage ベースから API ベースへ移行
- Hono RPC + TanStack Query を共通データ層として導入
- issue #31 の対応

## 主な変更
- `@todo-list/api/client` を公開し、web 側から Hono RPC の型付き client を参照できるように変更
- web 側に共通 API client / query keys / error handling / Query Provider を追加
- `useTasks` `useWorkRecords` `useTimer` を API 呼び出しベースへ差し替え
- `useCurrentTimerSession` を追加し、タイマー復旧状態を API から扱うように変更
- 各 page を Server Component で初期フェッチする構成へ変更
- 非同期 mutation に合わせてタスク追加、カテゴリ追加、タイマー開始・完了まわりの UI を調整

## あわせて修正した内容
- `web:3000 -> api:3001` のブラウザ動作確認で見つかった CORS 不足を API 側で修正
- `DialogContent` の説明不足によるアクセシビリティ warning を修正
- root の `biome check .` が `.claude/worktrees` と `.pnpm-store` を拾って落ちる問題を除外設定で修正
- Codex から Playwright MCP を使えるように `.codex/config.toml` を追加

## テスト
- `pnpm --filter @todo-list/api test`
- `pnpm --filter @todo-list/web test`
- `pnpm build`
- `pnpm format:check`

Closes #31