### PR TITLE
fix: ミューテーション実行中のボタン連打防止

### DIFF
--- a/.agent-rules/web/html-semantics.md
+++ b/.agent-rules/web/html-semantics.md
@@ -1,6 +1,7 @@
 ---
 paths:
-  - "apps/web/src/**/*.tsx"
+  - "apps/web/src/views/**/*.tsx"
+  - "apps/web/src/shared/ui/**/*.tsx"
 ---
 
 # HTML セマンティクスルール

--- a/.agent-rules/web/interactive-color-rules.md
+++ b/.agent-rules/web/interactive-color-rules.md
@@ -1,7 +1,8 @@
 ---
 paths:
-  - "apps/web/src/**/*.tsx"
-  - "apps/web/src/**/*.css"
+  - "apps/web/src/views/**/*.tsx"
+  - "apps/web/src/shared/ui/**/*.tsx"
+  - "apps/web/src/app/globals.css"
 ---
 
 # インタラクティブUI カラールール

--- a/.agent-rules/web/mutation-guard.md
+++ b/.agent-rules/web/mutation-guard.md
@@ -1,0 +1,44 @@
+---
+paths:
+  - "apps/web/src/views/**/*.tsx"
+  - "apps/web/src/shared/ui/**/*.tsx"
+---
+
+# ミューテーション多重実行防止ルール
+
+ミューテーションを実行するボタン・フォームには、必ず多重実行防止を実装すること。
+
+## ボタン（onClick）
+
+`shared/ui/loading-button.tsx` の `LoadingButton` を使い、`loading` prop に mutation の `isPending` を渡す。
+
+```tsx
+<LoadingButton loading={isDeletingTask} onClick={onConfirm}>
+  削除
+</LoadingButton>
+```
+
+## フォーム（onSubmit）
+
+1. submit ボタンに `LoadingButton` + `loading` を設定する
+2. `handleSubmit` の冒頭で `if (loading) return` ガードを入れる（Enter キーによる再送信防止）
+
+```tsx
+const handleSubmit = async (e: React.SubmitEvent<HTMLFormElement>) => {
+  e.preventDefault();
+  if (loading) return;
+  await onSubmit(data);
+};
+```
+
+## 複合操作（複数の非同期処理 + 画面遷移）
+
+ローカルの loading state を使い、以下を守る:
+
+- ハンドラ冒頭で `if (loadingAction) return` ガードを入れる
+- `router.push` 後は loading を解除しない（コンポーネントのアンマウントに任せる）
+- エラー時のみ `catch` で loading を解除する
+
+## isPending の取得元
+
+`useTasks` フックが各 mutation の `isPending` を返す（`isAddingTask`, `isUpdatingTask`, `isDeletingTask`, `isAddingCategory`, `isUpdatingCategory`, `isDeletingCategory`）。

--- a/.agent-rules/web/testing.md
+++ b/.agent-rules/web/testing.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - "apps/web/src/shared/hooks/**"
+  - "apps/web/src/shared/lib/**"
+---
+
+# Web テストルール
+
+## テスト必須ディレクトリ
+
+以下のディレクトリのファイルを追加・変更した場合、対応するテストを書くこと。
+
+- `apps/web/src/shared/hooks/` — カスタムフック
+- `apps/web/src/shared/lib/` — ユーティリティ関数（`api/`, `supabase/` 配下は除く）
+
+## テスト不要
+
+- `apps/web/src/app/` — Next.js ルーティング層
+- `apps/web/src/views/` — ページコンポーネント
+- `apps/web/src/shared/ui/` — UI コンポーネント
+
+## 規約
+
+- テストファイルは `__tests__/` ディレクトリに `<対象ファイル名>.test.ts(x)` で配置する
+- テストランナー: Vitest

--- a/apps/web/src/shared/hooks/use-tasks.ts
+++ b/apps/web/src/shared/hooks/use-tasks.ts
@@ -57,6 +57,12 @@ type UseTasksReturn = {
   addCategory: (name: string, color: string) => Promise<string>;
   updateCategory: (id: string, name: string, color: string) => Promise<void>;
   deleteCategory: (id: string) => Promise<void>;
+  isAddingTask: boolean;
+  isUpdatingTask: boolean;
+  isDeletingTask: boolean;
+  isAddingCategory: boolean;
+  isUpdatingCategory: boolean;
+  isDeletingCategory: boolean;
 };
 
 function normalizeCategoryId(categoryId: string) {
@@ -353,5 +359,11 @@ export function useTasks(initialData?: TasksInitialData): UseTasksReturn {
     addCategory: addCategoryAction,
     updateCategory: updateCategoryAction,
     deleteCategory: deleteCategoryAction,
+    isAddingTask: createTaskMutation.isPending,
+    isUpdatingTask: updateTaskMutation.isPending,
+    isDeletingTask: deleteTaskMutation.isPending,
+    isAddingCategory: createCategoryMutation.isPending,
+    isUpdatingCategory: updateCategoryMutation.isPending,
+    isDeletingCategory: deleteCategoryMutation.isPending,
   };
 }

--- a/apps/web/src/shared/ui/add-task-form.tsx
+++ b/apps/web/src/shared/ui/add-task-form.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 
 import type { Category } from "@/shared/types/task";
 import { CategorySelect } from "@/shared/ui/category-select";
+import { LoadingButton } from "@/shared/ui/loading-button";
 import { Button } from "@/shared/ui/shadcn/button";
 import { DatePickerField } from "@/shared/ui/shadcn/date-picker-field";
 import {
@@ -33,6 +34,7 @@ interface AddTaskFormProps {
   onCreateCategory: (name: string, color: string) => Promise<string>;
   categories: Category[];
   editingTask?: TaskFormData & { id: string };
+  loading?: boolean;
 }
 
 export function AddTaskForm({
@@ -41,6 +43,7 @@ export function AddTaskForm({
   onCreateCategory,
   categories,
   editingTask,
+  loading = false,
 }: AddTaskFormProps) {
   const [name, setName] = useState(editingTask?.name ?? "");
   const [categoryId, setCategoryId] = useState(editingTask?.categoryId ?? "");
@@ -128,9 +131,9 @@ export function AddTaskForm({
         >
           キャンセル
         </Button>
-        <Button type="submit" className="flex-1">
+        <LoadingButton type="submit" className="flex-1" loading={loading}>
           {isEditing ? "更新" : "追加"}
-        </Button>
+        </LoadingButton>
       </DialogFooter>
     </form>
   );

--- a/apps/web/src/shared/ui/add-task-form.tsx
+++ b/apps/web/src/shared/ui/add-task-form.tsx
@@ -59,6 +59,7 @@ export function AddTaskForm({
 
   const handleSubmit = async (e: React.SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (loading) return;
     if (!name.trim()) {
       setNameError(true);
       return;

--- a/apps/web/src/shared/ui/add-task-modal.tsx
+++ b/apps/web/src/shared/ui/add-task-modal.tsx
@@ -22,6 +22,7 @@ interface AddTaskModalProps {
   onCreateCategory: (name: string, color: string) => Promise<string>;
   categories: Category[];
   editingTask?: TaskFormData & { id: string };
+  loading?: boolean;
 }
 
 export function AddTaskModal({
@@ -31,6 +32,7 @@ export function AddTaskModal({
   onCreateCategory,
   categories,
   editingTask,
+  loading,
 }: AddTaskModalProps) {
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
@@ -45,6 +47,7 @@ export function AddTaskModal({
           onCreateCategory={onCreateCategory}
           categories={categories}
           editingTask={editingTask}
+          loading={loading}
         />
       </DialogContent>
     </Dialog>

--- a/apps/web/src/shared/ui/delete-confirm-dialog.tsx
+++ b/apps/web/src/shared/ui/delete-confirm-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { LoadingButton } from "@/shared/ui/loading-button";
 import { Button } from "@/shared/ui/shadcn/button";
 import {
   Dialog,
@@ -15,6 +16,7 @@ interface DeleteConfirmDialogProps {
   taskName: string;
   onConfirm: () => void;
   onCancel: () => void;
+  loading?: boolean;
 }
 
 export function DeleteConfirmDialog({
@@ -22,6 +24,7 @@ export function DeleteConfirmDialog({
   taskName,
   onConfirm,
   onCancel,
+  loading = false,
 }: DeleteConfirmDialogProps) {
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
@@ -36,9 +39,13 @@ export function DeleteConfirmDialog({
           <Button variant="outline" onClick={onCancel}>
             キャンセル
           </Button>
-          <Button variant="destructive" onClick={onConfirm}>
+          <LoadingButton
+            variant="destructive"
+            onClick={onConfirm}
+            loading={loading}
+          >
             削除
-          </Button>
+          </LoadingButton>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/shared/ui/loading-button.tsx
+++ b/apps/web/src/shared/ui/loading-button.tsx
@@ -1,0 +1,29 @@
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/shared/lib/utils";
+import { Button } from "@/shared/ui/shadcn/button";
+
+type LoadingButtonProps = React.ComponentProps<typeof Button> & {
+  loading?: boolean;
+};
+
+export function LoadingButton({
+  loading = false,
+  disabled,
+  children,
+  className,
+  ...props
+}: LoadingButtonProps) {
+  return (
+    <Button
+      disabled={disabled || loading}
+      className={cn("relative", className)}
+      {...props}
+    >
+      {loading && (
+        <Loader2 className="absolute animate-spin" aria-hidden="true" />
+      )}
+      <span className={loading ? "invisible" : undefined}>{children}</span>
+    </Button>
+  );
+}

--- a/apps/web/src/views/home/ui/home-page.tsx
+++ b/apps/web/src/views/home/ui/home-page.tsx
@@ -41,6 +41,9 @@ export function HomePage({
     setNextTask,
     unsetNextTask,
     addCategory,
+    isAddingTask,
+    isUpdatingTask,
+    isDeletingTask,
   } = useTasks({
     tasks: initialTasks,
     categories: initialCategories,
@@ -141,6 +144,7 @@ export function HomePage({
         onCreateCategory={addCategory}
         categories={categories}
         editingTask={editingTask}
+        loading={editingTask ? isUpdatingTask : isAddingTask}
       />
 
       {deleteTarget && (
@@ -149,6 +153,7 @@ export function HomePage({
           taskName={deleteTarget.name}
           onConfirm={handleConfirmDelete}
           onCancel={() => setDeleteTarget(null)}
+          loading={isDeletingTask}
         />
       )}
     </div>

--- a/apps/web/src/views/settings/ui/category-delete-dialog.tsx
+++ b/apps/web/src/views/settings/ui/category-delete-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { LoadingButton } from "@/shared/ui/loading-button";
 import { Button } from "@/shared/ui/shadcn/button";
 import {
   Dialog,
@@ -15,6 +16,7 @@ interface CategoryDeleteDialogProps {
   categoryName: string;
   onConfirm: () => void;
   onCancel: () => void;
+  loading?: boolean;
 }
 
 export function CategoryDeleteDialog({
@@ -22,6 +24,7 @@ export function CategoryDeleteDialog({
   categoryName,
   onConfirm,
   onCancel,
+  loading = false,
 }: CategoryDeleteDialogProps) {
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
@@ -37,9 +40,13 @@ export function CategoryDeleteDialog({
           <Button variant="outline" onClick={onCancel}>
             キャンセル
           </Button>
-          <Button variant="destructive" onClick={onConfirm}>
+          <LoadingButton
+            variant="destructive"
+            onClick={onConfirm}
+            loading={loading}
+          >
             削除
-          </Button>
+          </LoadingButton>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/views/settings/ui/category-form.tsx
+++ b/apps/web/src/views/settings/ui/category-form.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { CATEGORY_COLORS } from "@/shared/constants/category-colors";
 import { cn } from "@/shared/lib/utils";
 import type { Category } from "@/shared/types/task";
+import { LoadingButton } from "@/shared/ui/loading-button";
 import { Button } from "@/shared/ui/shadcn/button";
 import { Input } from "@/shared/ui/shadcn/input";
 
@@ -12,12 +13,14 @@ interface CategoryFormProps {
   editingCategory: Category | null;
   onSubmit: (name: string, color: string) => Promise<void>;
   onCancel: () => void;
+  loading?: boolean;
 }
 
 export function CategoryForm({
   editingCategory,
   onSubmit,
   onCancel,
+  loading = false,
 }: CategoryFormProps) {
   const [name, setName] = useState(editingCategory?.name ?? "");
   const [color, setColor] = useState(
@@ -77,7 +80,9 @@ export function CategoryForm({
         <Button type="button" variant="outline" onClick={onCancel}>
           キャンセル
         </Button>
-        <Button type="submit">{submitLabel}</Button>
+        <LoadingButton type="submit" loading={loading}>
+          {submitLabel}
+        </LoadingButton>
       </div>
     </form>
   );

--- a/apps/web/src/views/settings/ui/category-form.tsx
+++ b/apps/web/src/views/settings/ui/category-form.tsx
@@ -33,6 +33,7 @@ export function CategoryForm({
 
   const handleSubmit = async (e: React.SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (loading) return;
     const trimmed = name.trim();
     if (!trimmed) return;
     await onSubmit(trimmed, color);

--- a/apps/web/src/views/settings/ui/settings-page.tsx
+++ b/apps/web/src/views/settings/ui/settings-page.tsx
@@ -36,11 +36,19 @@ export function SettingsPage({
   initialCategories,
 }: SettingsPageProps) {
   const router = useRouter();
-  const { tasks, categories, addCategory, updateCategory, deleteCategory } =
-    useTasks({
-      tasks: initialTasks,
-      categories: initialCategories,
-    } satisfies TasksInitialData);
+  const {
+    tasks,
+    categories,
+    addCategory,
+    updateCategory,
+    deleteCategory,
+    isAddingCategory,
+    isUpdatingCategory,
+    isDeletingCategory,
+  } = useTasks({
+    tasks: initialTasks,
+    categories: initialCategories,
+  } satisfies TasksInitialData);
 
   const [formState, setFormState] = useState<FormState>({ mode: "closed" });
   const [deleteTarget, setDeleteTarget] = useState<Category | null>(null);
@@ -140,6 +148,11 @@ export function SettingsPage({
                   editingCategory={editingCategory}
                   onSubmit={handleFormSubmit}
                   onCancel={handleFormCancel}
+                  loading={
+                    formState.mode === "edit"
+                      ? isUpdatingCategory
+                      : isAddingCategory
+                  }
                 />
               </div>
             )}
@@ -166,6 +179,11 @@ export function SettingsPage({
                   editingCategory={editingCategory}
                   onSubmit={handleFormSubmit}
                   onCancel={handleFormCancel}
+                  loading={
+                    formState.mode === "edit"
+                      ? isUpdatingCategory
+                      : isAddingCategory
+                  }
                 />
               </DialogContent>
             </Dialog>
@@ -181,6 +199,7 @@ export function SettingsPage({
           categoryName={deleteTarget.name}
           onConfirm={handleConfirmDelete}
           onCancel={() => setDeleteTarget(null)}
+          loading={isDeletingCategory}
         />
       )}
     </div>

--- a/apps/web/src/views/tasks/ui/tasks-page.tsx
+++ b/apps/web/src/views/tasks/ui/tasks-page.tsx
@@ -42,6 +42,9 @@ export function TasksPage({ initialTasks, initialCategories }: TasksPageProps) {
     setNextTask,
     unsetNextTask,
     addCategory,
+    isAddingTask,
+    isUpdatingTask,
+    isDeletingTask,
   } = useTasks({
     tasks: initialTasks,
     categories: initialCategories,
@@ -201,6 +204,7 @@ export function TasksPage({ initialTasks, initialCategories }: TasksPageProps) {
         onCreateCategory={addCategory}
         categories={categories}
         editingTask={editingTask}
+        loading={editingTask ? isUpdatingTask : isAddingTask}
       />
 
       {deleteTarget && (
@@ -209,6 +213,7 @@ export function TasksPage({ initialTasks, initialCategories }: TasksPageProps) {
           taskName={deleteTarget.name}
           onConfirm={handleConfirmDelete}
           onCancel={() => setDeleteTarget(null)}
+          loading={isDeletingTask}
         />
       )}
     </div>

--- a/apps/web/src/views/timer/ui/timer-end-dialog.tsx
+++ b/apps/web/src/views/timer/ui/timer-end-dialog.tsx
@@ -1,6 +1,6 @@
 import { Bell, Check, Pause, RotateCw } from "lucide-react";
 
-import { Button } from "@/shared/ui/shadcn/button";
+import { LoadingButton } from "@/shared/ui/loading-button";
 import {
   Dialog,
   DialogContent,
@@ -9,12 +9,15 @@ import {
   DialogTitle,
 } from "@/shared/ui/shadcn/dialog";
 
+type TimerLoadingAction = "complete" | "continue" | "interrupt";
+
 interface TimerEndDialogProps {
   open: boolean;
   taskName: string;
   onComplete: () => void;
   onContinue: () => void;
   onInterrupt: () => void;
+  loadingAction?: TimerLoadingAction | null;
 }
 
 export function TimerEndDialog({
@@ -23,7 +26,9 @@ export function TimerEndDialog({
   onComplete,
   onContinue,
   onInterrupt,
+  loadingAction = null,
 }: TimerEndDialogProps) {
+  const isLoading = loadingAction !== null;
   return (
     <Dialog open={open}>
       <DialogContent showCloseButton={false} className="max-w-80 gap-5 p-7">
@@ -40,29 +45,35 @@ export function TimerEndDialog({
         </DialogHeader>
 
         <div className="flex flex-col gap-2.5">
-          <Button
+          <LoadingButton
             onClick={onComplete}
             className="h-12 rounded-3xl text-base font-semibold"
+            loading={loadingAction === "complete"}
+            disabled={isLoading}
           >
             <Check className="size-4" />
             完了
-          </Button>
-          <Button
+          </LoadingButton>
+          <LoadingButton
             variant="secondary"
             onClick={onContinue}
             className="h-12 rounded-3xl text-base font-semibold"
+            loading={loadingAction === "continue"}
+            disabled={isLoading}
           >
             <RotateCw className="size-4" />
             継続する
-          </Button>
-          <Button
+          </LoadingButton>
+          <LoadingButton
             variant="outline"
             onClick={onInterrupt}
             className="h-12 rounded-3xl text-base font-semibold"
+            loading={loadingAction === "interrupt"}
+            disabled={isLoading}
           >
             <Pause className="size-4" />
             中断する
-          </Button>
+          </LoadingButton>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/views/timer/ui/timer-page-content.tsx
+++ b/apps/web/src/views/timer/ui/timer-page-content.tsx
@@ -119,6 +119,7 @@ export function TimerPageContent({
   const [loadingAction, setLoadingAction] = useState<TimerAction | null>(null);
 
   const handleComplete = useCallback(async () => {
+    if (loadingAction) return;
     setLoadingAction("complete");
     try {
       const result = await timer.complete();
@@ -127,30 +128,32 @@ export function TimerPageContent({
       }
       await recordWork(result, "completed");
       router.push("/");
-    } finally {
+    } catch {
       setLoadingAction(null);
     }
-  }, [timer, taskId, completeTask, recordWork, router]);
+  }, [loadingAction, timer, taskId, completeTask, recordWork, router]);
 
   const handleInterrupt = useCallback(async () => {
+    if (loadingAction) return;
     setLoadingAction("interrupt");
     try {
       const result = await timer.interrupt();
       await recordWork(result, "interrupted");
       router.push("/");
-    } finally {
+    } catch {
       setLoadingAction(null);
     }
-  }, [timer, recordWork, router]);
+  }, [loadingAction, timer, recordWork, router]);
 
   const handleContinue = useCallback(async () => {
+    if (loadingAction) return;
     setLoadingAction("continue");
     try {
       await timer.restart();
     } finally {
       setLoadingAction(null);
     }
-  }, [timer]);
+  }, [loadingAction, timer]);
 
   if (!taskId) {
     return (

--- a/apps/web/src/views/timer/ui/timer-page-content.tsx
+++ b/apps/web/src/views/timer/ui/timer-page-content.tsx
@@ -3,7 +3,7 @@
 import { format } from "date-fns";
 import { Check, Pause } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { NAV_ROUTES } from "@/shared/constants/routes";
 import { useLogout } from "@/shared/hooks/use-logout";
@@ -17,8 +17,8 @@ import {
 import type { Category, Task } from "@/shared/types/task";
 import type { TimerSession } from "@/shared/types/timer";
 import type { WorkRecord } from "@/shared/types/work-record";
+import { LoadingButton } from "@/shared/ui/loading-button";
 import { Badge } from "@/shared/ui/shadcn/badge";
-import { Button } from "@/shared/ui/shadcn/button";
 import { Sidebar } from "@/shared/ui/sidebar";
 import { TabBar } from "@/shared/ui/tab-bar";
 import { TimerEndDialog } from "./timer-end-dialog";
@@ -115,23 +115,41 @@ export function TimerPageContent({
     [addWorkRecord],
   );
 
+  type TimerAction = "complete" | "interrupt" | "continue";
+  const [loadingAction, setLoadingAction] = useState<TimerAction | null>(null);
+
   const handleComplete = useCallback(async () => {
-    const result = await timer.complete();
-    if (taskId) {
-      await completeTask(taskId);
+    setLoadingAction("complete");
+    try {
+      const result = await timer.complete();
+      if (taskId) {
+        await completeTask(taskId);
+      }
+      await recordWork(result, "completed");
+      router.push("/");
+    } finally {
+      setLoadingAction(null);
     }
-    await recordWork(result, "completed");
-    router.push("/");
   }, [timer, taskId, completeTask, recordWork, router]);
 
   const handleInterrupt = useCallback(async () => {
-    const result = await timer.interrupt();
-    await recordWork(result, "interrupted");
-    router.push("/");
+    setLoadingAction("interrupt");
+    try {
+      const result = await timer.interrupt();
+      await recordWork(result, "interrupted");
+      router.push("/");
+    } finally {
+      setLoadingAction(null);
+    }
   }, [timer, recordWork, router]);
 
   const handleContinue = useCallback(async () => {
-    await timer.restart();
+    setLoadingAction("continue");
+    try {
+      await timer.restart();
+    } finally {
+      setLoadingAction(null);
+    }
   }, [timer]);
 
   if (!taskId) {
@@ -164,21 +182,25 @@ export function TimerPageContent({
           />
 
           <div className="flex items-center gap-3">
-            <Button
+            <LoadingButton
               variant="secondary"
               onClick={handleInterrupt}
               className="h-12 rounded-3xl px-6 text-base font-semibold"
+              loading={loadingAction === "interrupt"}
+              disabled={loadingAction !== null}
             >
               <Pause className="size-4" />
               中断
-            </Button>
-            <Button
+            </LoadingButton>
+            <LoadingButton
               onClick={handleComplete}
               className="h-12 rounded-3xl px-6 text-base font-semibold"
+              loading={loadingAction === "complete"}
+              disabled={loadingAction !== null}
             >
               <Check className="size-4" />
               完了
-            </Button>
+            </LoadingButton>
           </div>
         </main>
       </div>
@@ -191,6 +213,7 @@ export function TimerPageContent({
         onComplete={handleComplete}
         onContinue={handleContinue}
         onInterrupt={handleInterrupt}
+        loadingAction={loadingAction}
       />
     </div>
   );


### PR DESCRIPTION
## 概要

ミューテーション実行中のボタンに連打防止の制御を追加し、重複実行を防止する。

closes #39

## 変更内容

- `LoadingButton` コンポーネントを新規作成（shadcn Button のラップ、loading 中はスピナー表示 + disabled）
- `useTasks` フックから各 mutation の `isPending` を返却するよう拡張
- 全ミューテーション箇所のボタンを `LoadingButton` に差し替え、`loading` prop で制御
  - タスク追加・編集フォーム
  - カテゴリ追加・編集フォーム
  - タスク削除・カテゴリ削除ダイアログ
  - タイマー操作（完了・中断・継続）
- フォームの `handleSubmit` に `if (loading) return` ガードを追加（Enter キーによる再送信防止）
- タイマーの複合操作で `router.push` 後に loading を解除しないよう変更（アンマウントに任せる）
- agent-rules に `mutation-guard.md`（多重実行防止ルール）と `testing.md`（テストカバレッジルール）を追加
- `html-semantics.md` / `interactive-color-rules.md` の frontmatter パスを適切な範囲に絞り込み

## 確認方法

- [x] `pnpm build` が通る
- [x] `pnpm lint` が通る
- [ ] ブラウザで動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
