### PR TITLE
feat: Idempotency-Key によるサーバー側多重リクエスト防止

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,6 +5,7 @@ import { tasksRoute } from "./features/tasks/route";
 import { timerSessionsRoute } from "./features/timer-sessions/route";
 import { workRecordsRoute } from "./features/work-records/route";
 import { authMiddleware } from "./shared/auth/middleware";
+import { idempotencyMiddleware } from "./shared/idempotency/middleware";
 
 function resolveCorsOrigin(origin: string) {
   if (origin.startsWith("http://localhost:")) {
@@ -24,10 +25,11 @@ const app = new Hono()
     cors({
       origin: resolveCorsOrigin,
       allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-      allowHeaders: ["Content-Type", "Authorization"],
+      allowHeaders: ["Content-Type", "Authorization", "Idempotency-Key"],
     }),
   )
   .use("/*", authMiddleware)
+  .use("/*", idempotencyMiddleware)
   .route("/tasks", tasksRoute)
   .route("/categories", categoriesRoute)
   .route("/work-records", workRecordsRoute)

--- a/apps/api/src/shared/idempotency/__tests__/idempotency.test.ts
+++ b/apps/api/src/shared/idempotency/__tests__/idempotency.test.ts
@@ -78,6 +78,26 @@ describe("Idempotency middleware", () => {
     expect(res.status).toBe(201);
   });
 
+  it("should allow retry with same key after failed request", async () => {
+    const key = crypto.randomUUID();
+
+    // バリデーションエラー（400）でキーが消費されないことを確認
+    const failed = await app.request("/categories", {
+      method: "POST",
+      headers: { ...headers, "Idempotency-Key": key },
+      body: JSON.stringify({ name: "", color: "#000000" }),
+    });
+    expect(failed.status).toBe(400);
+
+    // 同じキーで正しいリクエストをリトライ
+    const retry = await app.request("/categories", {
+      method: "POST",
+      headers: { ...headers, "Idempotency-Key": key },
+      body: JSON.stringify({ name: "Test", color: "#000000" }),
+    });
+    expect(retry.status).toBe(201);
+  });
+
   it("should not apply to GET requests", async () => {
     const key = crypto.randomUUID();
 

--- a/apps/api/src/shared/idempotency/__tests__/idempotency.test.ts
+++ b/apps/api/src/shared/idempotency/__tests__/idempotency.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanDatabase, prisma } from "../../../__tests__/helpers/db";
+import app from "../../../app";
+
+vi.mock("jose", () => ({
+  createRemoteJWKSet: vi.fn(),
+  jwtVerify: vi.fn().mockResolvedValue({
+    payload: { sub: "test-user-id" },
+  }),
+}));
+
+const headers = {
+  "Content-Type": "application/json",
+  Authorization: "Bearer test-token",
+};
+
+describe("Idempotency middleware", () => {
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  afterAll(async () => {
+    await cleanDatabase();
+    await prisma.$disconnect();
+  });
+
+  it("should allow first request with Idempotency-Key", async () => {
+    const res = await app.request("/categories", {
+      method: "POST",
+      headers: { ...headers, "Idempotency-Key": crypto.randomUUID() },
+      body: JSON.stringify({ name: "Test", color: "#000000" }),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("should reject duplicate request with same Idempotency-Key", async () => {
+    const key = crypto.randomUUID();
+
+    const first = await app.request("/categories", {
+      method: "POST",
+      headers: { ...headers, "Idempotency-Key": key },
+      body: JSON.stringify({ name: "Test", color: "#000000" }),
+    });
+    expect(first.status).toBe(201);
+
+    const second = await app.request("/categories", {
+      method: "POST",
+      headers: { ...headers, "Idempotency-Key": key },
+      body: JSON.stringify({ name: "Test", color: "#000000" }),
+    });
+    expect(second.status).toBe(409);
+  });
+
+  it("should allow requests with different Idempotency-Keys", async () => {
+    const first = await app.request("/categories", {
+      method: "POST",
+      headers: { ...headers, "Idempotency-Key": crypto.randomUUID() },
+      body: JSON.stringify({ name: "Test1", color: "#000000" }),
+    });
+    expect(first.status).toBe(201);
+
+    const second = await app.request("/categories", {
+      method: "POST",
+      headers: { ...headers, "Idempotency-Key": crypto.randomUUID() },
+      body: JSON.stringify({ name: "Test2", color: "#000000" }),
+    });
+    expect(second.status).toBe(201);
+  });
+
+  it("should allow request without Idempotency-Key header", async () => {
+    const res = await app.request("/categories", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ name: "Test", color: "#000000" }),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("should not apply to GET requests", async () => {
+    const key = crypto.randomUUID();
+
+    const first = await app.request("/categories", {
+      headers: { ...headers, "Idempotency-Key": key },
+    });
+    expect(first.status).toBe(200);
+
+    const second = await app.request("/categories", {
+      headers: { ...headers, "Idempotency-Key": key },
+    });
+    expect(second.status).toBe(200);
+  });
+});

--- a/apps/api/src/shared/idempotency/__tests__/idempotency.test.ts
+++ b/apps/api/src/shared/idempotency/__tests__/idempotency.test.ts
@@ -34,7 +34,7 @@ describe("Idempotency middleware", () => {
     expect(res.status).toBe(201);
   });
 
-  it("should reject duplicate request with same Idempotency-Key", async () => {
+  it("should replay original response for duplicate request with same Idempotency-Key", async () => {
     const key = crypto.randomUUID();
 
     const first = await app.request("/categories", {
@@ -43,13 +43,22 @@ describe("Idempotency middleware", () => {
       body: JSON.stringify({ name: "Test", color: "#000000" }),
     });
     expect(first.status).toBe(201);
+    const firstBody = await first.json();
 
     const second = await app.request("/categories", {
       method: "POST",
       headers: { ...headers, "Idempotency-Key": key },
       body: JSON.stringify({ name: "Test", color: "#000000" }),
     });
-    expect(second.status).toBe(409);
+    expect(second.status).toBe(201);
+    const secondBody = await second.json();
+
+    // 同じレスポンスがリプレイされる（重複作成されない）
+    expect(secondBody.id).toBe(firstBody.id);
+
+    // DB に1件だけ存在する
+    const count = await prisma.category.count();
+    expect(count).toBe(1);
   });
 
   it("should allow requests with different Idempotency-Keys", async () => {

--- a/apps/api/src/shared/idempotency/middleware.ts
+++ b/apps/api/src/shared/idempotency/middleware.ts
@@ -4,12 +4,17 @@ import type { AuthEnv } from "../auth/env";
 const TTL_MS = 5 * 60 * 1000;
 const CLEANUP_THRESHOLD = 1000;
 
-const store = new Map<string, number>();
+type IdempotencyEntry = {
+  timestamp: number;
+  response?: Response;
+};
+
+const store = new Map<string, IdempotencyEntry>();
 
 function cleanup() {
   const now = Date.now();
-  for (const [key, timestamp] of store) {
-    if (now - timestamp > TTL_MS) {
+  for (const [key, entry] of store) {
+    if (now - entry.timestamp > TTL_MS) {
       store.delete(key);
     }
   }
@@ -34,20 +39,25 @@ export const idempotencyMiddleware = createMiddleware<AuthEnv>(
       cleanup();
     }
 
-    const storedTimestamp = store.get(compositeKey);
-    if (storedTimestamp !== undefined) {
-      if (Date.now() - storedTimestamp < TTL_MS) {
-        return c.json({ error: "Duplicate request" }, 409);
+    const existing = store.get(compositeKey);
+    if (existing && Date.now() - existing.timestamp < TTL_MS) {
+      if (existing.response) {
+        return existing.response.clone();
       }
-      store.delete(compositeKey);
+      return c.json({ error: "Duplicate request" }, 409);
     }
 
-    store.set(compositeKey, Date.now());
+    store.set(compositeKey, { timestamp: Date.now() });
     try {
       await next();
 
       const status = c.res.status;
-      if (status < 200 || status >= 300) {
+      if (status >= 200 && status < 300) {
+        store.set(compositeKey, {
+          timestamp: Date.now(),
+          response: c.res.clone(),
+        });
+      } else {
         store.delete(compositeKey);
       }
     } catch (e) {

--- a/apps/api/src/shared/idempotency/middleware.ts
+++ b/apps/api/src/shared/idempotency/middleware.ts
@@ -1,0 +1,48 @@
+import { createMiddleware } from "hono/factory";
+import type { AuthEnv } from "../auth/env";
+
+const TTL_MS = 5 * 60 * 1000;
+const CLEANUP_THRESHOLD = 1000;
+
+const store = new Map<string, number>();
+
+function cleanup() {
+  const now = Date.now();
+  for (const [key, timestamp] of store) {
+    if (now - timestamp > TTL_MS) {
+      store.delete(key);
+    }
+  }
+}
+
+export const idempotencyMiddleware = createMiddleware<AuthEnv>(
+  async (c, next) => {
+    const method = c.req.method;
+    if (method === "GET" || method === "HEAD" || method === "OPTIONS") {
+      return next();
+    }
+
+    const idempotencyKey = c.req.header("Idempotency-Key");
+    if (!idempotencyKey) {
+      return next();
+    }
+
+    const userId = c.get("userId");
+    const compositeKey = `${userId}:${idempotencyKey}`;
+
+    if (store.size > CLEANUP_THRESHOLD) {
+      cleanup();
+    }
+
+    const storedTimestamp = store.get(compositeKey);
+    if (storedTimestamp !== undefined) {
+      if (Date.now() - storedTimestamp < TTL_MS) {
+        return c.json({ error: "Duplicate request" }, 409);
+      }
+      store.delete(compositeKey);
+    }
+
+    store.set(compositeKey, Date.now());
+    await next();
+  },
+);

--- a/apps/api/src/shared/idempotency/middleware.ts
+++ b/apps/api/src/shared/idempotency/middleware.ts
@@ -44,5 +44,10 @@ export const idempotencyMiddleware = createMiddleware<AuthEnv>(
 
     store.set(compositeKey, Date.now());
     await next();
+
+    const status = c.res.status;
+    if (status < 200 || status >= 300) {
+      store.delete(compositeKey);
+    }
   },
 );

--- a/apps/api/src/shared/idempotency/middleware.ts
+++ b/apps/api/src/shared/idempotency/middleware.ts
@@ -33,7 +33,7 @@ export const idempotencyMiddleware = createMiddleware<AuthEnv>(
     }
 
     const userId = c.get("userId");
-    const compositeKey = `${userId}:${idempotencyKey}`;
+    const compositeKey = `${userId}:${method}:${c.req.path}:${idempotencyKey}`;
 
     if (store.size > CLEANUP_THRESHOLD) {
       cleanup();

--- a/apps/api/src/shared/idempotency/middleware.ts
+++ b/apps/api/src/shared/idempotency/middleware.ts
@@ -43,11 +43,16 @@ export const idempotencyMiddleware = createMiddleware<AuthEnv>(
     }
 
     store.set(compositeKey, Date.now());
-    await next();
+    try {
+      await next();
 
-    const status = c.res.status;
-    if (status < 200 || status >= 300) {
+      const status = c.res.status;
+      if (status < 200 || status >= 300) {
+        store.delete(compositeKey);
+      }
+    } catch (e) {
       store.delete(compositeKey);
+      throw e;
     }
   },
 );

--- a/apps/web/src/shared/hooks/use-current-timer-session.ts
+++ b/apps/web/src/shared/hooks/use-current-timer-session.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 
 import {
   createTimerSession,
@@ -20,27 +20,41 @@ export function useCurrentTimerSession(initialSession?: TimerSession | null) {
   });
 
   const createSessionMutation = useMutation({
-    mutationFn: createTimerSession,
+    mutationFn: (args: {
+      input: Parameters<typeof createTimerSession>[0];
+      key: string;
+    }) => createTimerSession(args.input, args.key),
     onSuccess: (createdSession) => {
       queryClient.setQueryData(queryKeys.timerSession, createdSession);
     },
   });
   const deleteSessionMutation = useMutation({
-    mutationFn: deleteCurrentTimerSession,
+    mutationFn: (args: { key: string }) => deleteCurrentTimerSession(args.key),
     onSuccess: () => {
       queryClient.setQueryData(queryKeys.timerSession, null);
     },
   });
 
+  const createSessionKeyRef = useRef(crypto.randomUUID());
+  const clearSessionKeyRef = useRef(crypto.randomUUID());
+
   const createSession = useCallback(
-    (input: Parameters<typeof createTimerSession>[0]) => {
-      return createSessionMutation.mutateAsync(input);
+    async (input: Parameters<typeof createTimerSession>[0]) => {
+      const result = await createSessionMutation.mutateAsync({
+        input,
+        key: createSessionKeyRef.current,
+      });
+      createSessionKeyRef.current = crypto.randomUUID();
+      return result;
     },
     [createSessionMutation],
   );
 
   const clearSession = useCallback(async () => {
-    await deleteSessionMutation.mutateAsync();
+    await deleteSessionMutation.mutateAsync({
+      key: clearSessionKeyRef.current,
+    });
+    clearSessionKeyRef.current = crypto.randomUUID();
   }, [deleteSessionMutation]);
 
   return {

--- a/apps/web/src/shared/hooks/use-tasks.ts
+++ b/apps/web/src/shared/hooks/use-tasks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import type { TaskStatus } from "@/shared/enums/task-statuses";
 import {
   createCategory,
@@ -107,8 +107,13 @@ export function useTasks(initialData?: TasksInitialData): UseTasksReturn {
     initialData: initialData?.categories,
   });
 
+  // --- mutations ---
+
   const createTaskMutation = useMutation({
-    mutationFn: createTask,
+    mutationFn: (args: {
+      input: Parameters<typeof createTask>[0];
+      key: string;
+    }) => createTask(args.input, args.key),
     onSuccess: (createdTask) => {
       queryClient.setQueryData<Task[]>(queryKeys.tasks, (prev = []) => [
         ...prev,
@@ -120,10 +125,12 @@ export function useTasks(initialData?: TasksInitialData): UseTasksReturn {
     mutationFn: ({
       id,
       input,
+      key,
     }: {
       id: string;
       input: ReturnType<typeof toTaskMutationInput>;
-    }) => updateTask(id, input),
+      key: string;
+    }) => updateTask(id, input, key),
     onSuccess: (updatedTask) => {
       queryClient.setQueryData<Task[]>(queryKeys.tasks, (prev = []) =>
         prev.map((task) => (task.id === updatedTask.id ? updatedTask : task)),
@@ -131,8 +138,9 @@ export function useTasks(initialData?: TasksInitialData): UseTasksReturn {
     },
   });
   const deleteTaskMutation = useMutation({
-    mutationFn: deleteTask,
-    onSuccess: (_, deletedTaskId) => {
+    mutationFn: (args: { id: string; key: string }) =>
+      deleteTask(args.id, args.key),
+    onSuccess: (_, { id: deletedTaskId }) => {
       queryClient.setQueryData<Task[]>(queryKeys.tasks, (prev = []) =>
         prev.filter((task) => task.id !== deletedTaskId),
       );
@@ -147,7 +155,10 @@ export function useTasks(initialData?: TasksInitialData): UseTasksReturn {
     },
   });
   const createCategoryMutation = useMutation({
-    mutationFn: createCategory,
+    mutationFn: (args: {
+      input: Parameters<typeof createCategory>[0];
+      key: string;
+    }) => createCategory(args.input, args.key),
     onSuccess: (createdCategory) => {
       queryClient.setQueryData<Category[]>(
         queryKeys.categories,
@@ -160,11 +171,13 @@ export function useTasks(initialData?: TasksInitialData): UseTasksReturn {
       id,
       color,
       name,
+      key,
     }: {
       id: string;
       color: string;
       name: string;
-    }) => updateCategory(id, { name, color }),
+      key: string;
+    }) => updateCategory(id, { name, color }, key),
     onSuccess: (updatedCategory) => {
       queryClient.setQueryData<Category[]>(queryKeys.categories, (prev = []) =>
         prev.map((category) =>
@@ -174,8 +187,9 @@ export function useTasks(initialData?: TasksInitialData): UseTasksReturn {
     },
   });
   const deleteCategoryMutation = useMutation({
-    mutationFn: deleteCategory,
-    onSuccess: (_, deletedCategoryId) => {
+    mutationFn: (args: { id: string; key: string }) =>
+      deleteCategory(args.id, args.key),
+    onSuccess: (_, { id: deletedCategoryId }) => {
       queryClient.setQueryData<Category[]>(queryKeys.categories, (prev = []) =>
         prev.filter((category) => category.id !== deletedCategoryId),
       );
@@ -188,6 +202,8 @@ export function useTasks(initialData?: TasksInitialData): UseTasksReturn {
       );
     },
   });
+
+  // --- helpers ---
 
   const resolveCategory = useCallback(
     (categoryId: string): Category => {
@@ -210,112 +226,163 @@ export function useTasks(initialData?: TasksInitialData): UseTasksReturn {
     async (
       id: string,
       recipe: (task: Task) => ReturnType<typeof toTaskMutationInput>,
+      key: string,
     ) => {
       const currentTask = tasks.find((task) => task.id === id);
       if (!currentTask) return;
       await updateTaskMutation.mutateAsync({
         id,
         input: recipe(currentTask),
+        key,
       });
     },
     [tasks, updateTaskMutation],
   );
 
+  // --- idempotency keys (アクション単位で管理) ---
+
+  const addTaskKeyRef = useRef(crypto.randomUUID());
+  const updateTaskKeyRef = useRef(crypto.randomUUID());
+  const deleteTaskKeyRef = useRef(crypto.randomUUID());
+  const toggleCompleteKeyRef = useRef(crypto.randomUUID());
+  const setNextKeyRef = useRef(crypto.randomUUID());
+  const unsetNextKeyRef = useRef(crypto.randomUUID());
+  const startWorkKeyRef = useRef(crypto.randomUUID());
+  const completeTaskKeyRef = useRef(crypto.randomUUID());
+  const addCategoryKeyRef = useRef(crypto.randomUUID());
+  const updateCategoryKeyRef = useRef(crypto.randomUUID());
+  const deleteCategoryKeyRef = useRef(crypto.randomUUID());
+
+  // --- actions ---
+
   const addTaskAction = useCallback(
     async (input: AddTaskInput) => {
       await createTaskMutation.mutateAsync({
-        name: input.name,
-        categoryId: normalizeCategoryId(input.categoryId),
-        scheduledDate: input.scheduledDate,
-        estimatedMinutes: input.estimatedMinutes,
+        input: {
+          name: input.name,
+          categoryId: normalizeCategoryId(input.categoryId),
+          scheduledDate: input.scheduledDate,
+          estimatedMinutes: input.estimatedMinutes,
+        },
+        key: addTaskKeyRef.current,
       });
+      addTaskKeyRef.current = crypto.randomUUID();
     },
     [createTaskMutation],
   );
 
   const updateTaskAction = useCallback(
     async (id: string, input: UpdateTaskInput) => {
-      await mutateTask(id, (task) =>
-        toTaskMutationInput(task, {
-          name: input.name,
-          categoryId: input.categoryId,
-          scheduledDate: input.scheduledDate,
-          estimatedMinutes: input.estimatedMinutes,
-        }),
+      await mutateTask(
+        id,
+        (task) =>
+          toTaskMutationInput(task, {
+            name: input.name,
+            categoryId: input.categoryId,
+            scheduledDate: input.scheduledDate,
+            estimatedMinutes: input.estimatedMinutes,
+          }),
+        updateTaskKeyRef.current,
       );
+      updateTaskKeyRef.current = crypto.randomUUID();
     },
     [mutateTask],
   );
 
   const deleteTaskAction = useCallback(
     async (id: string) => {
-      await deleteTaskMutation.mutateAsync(id);
+      await deleteTaskMutation.mutateAsync({
+        id,
+        key: deleteTaskKeyRef.current,
+      });
+      deleteTaskKeyRef.current = crypto.randomUUID();
     },
     [deleteTaskMutation],
   );
 
   const toggleComplete = useCallback(
     async (id: string) => {
-      await mutateTask(id, (task) => {
-        const nextStatus: TaskStatus = task.status === "done" ? "todo" : "done";
-        return toTaskMutationInput(task, {
-          status: nextStatus,
-          isNext: nextStatus === "done" ? false : task.isNext,
-        });
-      });
+      await mutateTask(
+        id,
+        (task) => {
+          const nextStatus: TaskStatus =
+            task.status === "done" ? "todo" : "done";
+          return toTaskMutationInput(task, {
+            status: nextStatus,
+            isNext: nextStatus === "done" ? false : task.isNext,
+          });
+        },
+        toggleCompleteKeyRef.current,
+      );
+      toggleCompleteKeyRef.current = crypto.randomUUID();
     },
     [mutateTask],
   );
 
   const setNextTask = useCallback(
     async (id: string) => {
+      const baseKey = setNextKeyRef.current;
       const currentTasks = tasks;
       await Promise.all(
         currentTasks
           .filter((task) => task.id === id || task.isNext)
-          .map((task) =>
+          .map((task, i) =>
             updateTaskMutation.mutateAsync({
               id: task.id,
               input: toTaskMutationInput(task, {
                 isNext: task.id === id,
               }),
+              key: `${baseKey}:${i}`,
             }),
           ),
       );
+      setNextKeyRef.current = crypto.randomUUID();
     },
     [tasks, updateTaskMutation],
   );
 
   const unsetNextTask = useCallback(
     async (id: string) => {
-      await mutateTask(id, (task) =>
-        toTaskMutationInput(task, {
-          isNext: false,
-        }),
+      await mutateTask(
+        id,
+        (task) =>
+          toTaskMutationInput(task, {
+            isNext: false,
+          }),
+        unsetNextKeyRef.current,
       );
+      unsetNextKeyRef.current = crypto.randomUUID();
     },
     [mutateTask],
   );
 
   const startWork = useCallback(
     async (id: string) => {
-      await mutateTask(id, (task) =>
-        toTaskMutationInput(task, {
-          status: "in_progress",
-        }),
+      await mutateTask(
+        id,
+        (task) =>
+          toTaskMutationInput(task, {
+            status: "in_progress",
+          }),
+        startWorkKeyRef.current,
       );
+      startWorkKeyRef.current = crypto.randomUUID();
     },
     [mutateTask],
   );
 
   const completeTask = useCallback(
     async (id: string) => {
-      await mutateTask(id, (task) =>
-        toTaskMutationInput(task, {
-          status: "done",
-          isNext: false,
-        }),
+      await mutateTask(
+        id,
+        (task) =>
+          toTaskMutationInput(task, {
+            status: "done",
+            isNext: false,
+          }),
+        completeTaskKeyRef.current,
       );
+      completeTaskKeyRef.current = crypto.randomUUID();
     },
     [mutateTask],
   );
@@ -323,9 +390,10 @@ export function useTasks(initialData?: TasksInitialData): UseTasksReturn {
   const addCategoryAction = useCallback(
     async (name: string, color: string) => {
       const category = await createCategoryMutation.mutateAsync({
-        name,
-        color,
+        input: { name, color },
+        key: addCategoryKeyRef.current,
       });
+      addCategoryKeyRef.current = crypto.randomUUID();
       return category.id;
     },
     [createCategoryMutation],
@@ -333,14 +401,24 @@ export function useTasks(initialData?: TasksInitialData): UseTasksReturn {
 
   const updateCategoryAction = useCallback(
     async (id: string, name: string, color: string) => {
-      await updateCategoryMutation.mutateAsync({ id, name, color });
+      await updateCategoryMutation.mutateAsync({
+        id,
+        name,
+        color,
+        key: updateCategoryKeyRef.current,
+      });
+      updateCategoryKeyRef.current = crypto.randomUUID();
     },
     [updateCategoryMutation],
   );
 
   const deleteCategoryAction = useCallback(
     async (id: string) => {
-      await deleteCategoryMutation.mutateAsync(id);
+      await deleteCategoryMutation.mutateAsync({
+        id,
+        key: deleteCategoryKeyRef.current,
+      });
+      deleteCategoryKeyRef.current = crypto.randomUUID();
     },
     [deleteCategoryMutation],
   );

--- a/apps/web/src/shared/hooks/use-work-records.ts
+++ b/apps/web/src/shared/hooks/use-work-records.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import type { WorkResult } from "@/shared/enums/work-results";
 import { createWorkRecord, fetchWorkRecords } from "@/shared/lib/api";
 import { queryKeys } from "@/shared/lib/api/query-keys";
@@ -50,7 +50,10 @@ export function useWorkRecords(
   });
 
   const createWorkRecordMutation = useMutation({
-    mutationFn: createWorkRecord,
+    mutationFn: (args: {
+      input: Parameters<typeof createWorkRecord>[0];
+      key: string;
+    }) => createWorkRecord(args.input, args.key),
     onSuccess: (createdRecord) => {
       queryClient.setQueryData<WorkRecord[]>(
         queryKeys.workRecords,
@@ -64,9 +67,15 @@ export function useWorkRecords(
     [workRecords, tasks],
   );
 
+  const addWorkRecordKeyRef = useRef(crypto.randomUUID());
+
   const addWorkRecord = useCallback(
     async (input: AddWorkRecordInput) => {
-      await createWorkRecordMutation.mutateAsync(input);
+      await createWorkRecordMutation.mutateAsync({
+        input,
+        key: addWorkRecordKeyRef.current,
+      });
+      addWorkRecordKeyRef.current = crypto.randomUUID();
     },
     [createWorkRecordMutation],
   );

--- a/apps/web/src/shared/lib/api/client.ts
+++ b/apps/web/src/shared/lib/api/client.ts
@@ -17,11 +17,15 @@ export function createApiClient(
 ) {
   return hc<AppType>(getApiBaseUrl(), {
     headers,
-    fetch: (input: RequestInfo | URL, init?: RequestInit) =>
-      fetch(input, {
-        ...init,
-        cache: "no-store",
-      }),
+    fetch: (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      const method = init?.method?.toUpperCase();
+      if (method && method !== "GET" && method !== "HEAD") {
+        headers.set("Idempotency-Key", crypto.randomUUID());
+      }
+      // Next.js の fetch キャッシュを無効化し、キャッシュ管理は TanStack Query に委ねる
+      return fetch(input, { ...init, headers, cache: "no-store" });
+    },
   });
 }
 

--- a/apps/web/src/shared/lib/api/client.ts
+++ b/apps/web/src/shared/lib/api/client.ts
@@ -17,20 +17,12 @@ export function createApiClient(
 ) {
   return hc<AppType>(getApiBaseUrl(), {
     headers,
-    fetch: (input: RequestInfo | URL, init?: RequestInit) => {
-      const headers = new Headers(init?.headers);
-      const method = init?.method?.toUpperCase();
-      if (
-        method &&
-        method !== "GET" &&
-        method !== "HEAD" &&
-        !headers.has("Idempotency-Key")
-      ) {
-        headers.set("Idempotency-Key", crypto.randomUUID());
-      }
-      // Next.js の fetch キャッシュを無効化し、キャッシュ管理は TanStack Query に委ねる
-      return fetch(input, { ...init, headers, cache: "no-store" });
-    },
+    // Next.js の fetch キャッシュを無効化し、キャッシュ管理は TanStack Query に委ねる
+    fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+      fetch(input, {
+        ...init,
+        cache: "no-store",
+      }),
   });
 }
 

--- a/apps/web/src/shared/lib/api/client.ts
+++ b/apps/web/src/shared/lib/api/client.ts
@@ -20,7 +20,12 @@ export function createApiClient(
     fetch: (input: RequestInfo | URL, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
       const method = init?.method?.toUpperCase();
-      if (method && method !== "GET" && method !== "HEAD") {
+      if (
+        method &&
+        method !== "GET" &&
+        method !== "HEAD" &&
+        !headers.has("Idempotency-Key")
+      ) {
         headers.set("Idempotency-Key", crypto.randomUUID());
       }
       // Next.js の fetch キャッシュを無効化し、キャッシュ管理は TanStack Query に委ねる

--- a/apps/web/src/shared/lib/api/index.ts
+++ b/apps/web/src/shared/lib/api/index.ts
@@ -30,25 +30,36 @@ export async function fetchTasks() {
   return tasks.map(normalizeTask);
 }
 
-export async function createTask(input: CreateTaskRequest) {
-  const response = await apiClient.tasks.$post({ json: input });
+export async function createTask(
+  input: CreateTaskRequest,
+  idempotencyKey: string,
+) {
+  const response = await apiClient.tasks.$post(
+    { json: input },
+    { headers: { "Idempotency-Key": idempotencyKey } },
+  );
   await expectOk(response, "Failed to create task");
   return normalizeTask((await response.json()) as CreateTaskSuccess);
 }
 
-export async function updateTask(id: string, input: UpdateTaskRequest) {
-  const response = await apiClient.tasks[":id"].$put({
-    param: { id },
-    json: input,
-  });
+export async function updateTask(
+  id: string,
+  input: UpdateTaskRequest,
+  idempotencyKey: string,
+) {
+  const response = await apiClient.tasks[":id"].$put(
+    { param: { id }, json: input },
+    { headers: { "Idempotency-Key": idempotencyKey } },
+  );
   await expectOk(response, "Failed to update task");
   return normalizeTask((await response.json()) as UpdateTaskSuccess);
 }
 
-export async function deleteTask(id: string) {
-  const response = await apiClient.tasks[":id"].$delete({
-    param: { id },
-  });
+export async function deleteTask(id: string, idempotencyKey: string) {
+  const response = await apiClient.tasks[":id"].$delete(
+    { param: { id } },
+    { headers: { "Idempotency-Key": idempotencyKey } },
+  );
   await expectOk(response, "Failed to delete task");
 }
 
@@ -59,25 +70,36 @@ export async function fetchCategories() {
   return categories.map(normalizeCategory);
 }
 
-export async function createCategory(input: CreateCategoryRequest) {
-  const response = await apiClient.categories.$post({ json: input });
+export async function createCategory(
+  input: CreateCategoryRequest,
+  idempotencyKey: string,
+) {
+  const response = await apiClient.categories.$post(
+    { json: input },
+    { headers: { "Idempotency-Key": idempotencyKey } },
+  );
   await expectOk(response, "Failed to create category");
   return normalizeCategory((await response.json()) as CreateCategorySuccess);
 }
 
-export async function updateCategory(id: string, input: UpdateCategoryRequest) {
-  const response = await apiClient.categories[":id"].$put({
-    param: { id },
-    json: input,
-  });
+export async function updateCategory(
+  id: string,
+  input: UpdateCategoryRequest,
+  idempotencyKey: string,
+) {
+  const response = await apiClient.categories[":id"].$put(
+    { param: { id }, json: input },
+    { headers: { "Idempotency-Key": idempotencyKey } },
+  );
   await expectOk(response, "Failed to update category");
   return normalizeCategory((await response.json()) as UpdateCategorySuccess);
 }
 
-export async function deleteCategory(id: string) {
-  const response = await apiClient.categories[":id"].$delete({
-    param: { id },
-  });
+export async function deleteCategory(id: string, idempotencyKey: string) {
+  const response = await apiClient.categories[":id"].$delete(
+    { param: { id } },
+    { headers: { "Idempotency-Key": idempotencyKey } },
+  );
   await expectOk(response, "Failed to delete category");
 }
 
@@ -88,8 +110,14 @@ export async function fetchWorkRecords() {
   return records.map(normalizeWorkRecord);
 }
 
-export async function createWorkRecord(input: CreateWorkRecordRequest) {
-  const response = await apiClient["work-records"].$post({ json: input });
+export async function createWorkRecord(
+  input: CreateWorkRecordRequest,
+  idempotencyKey: string,
+) {
+  const response = await apiClient["work-records"].$post(
+    { json: input },
+    { headers: { "Idempotency-Key": idempotencyKey } },
+  );
   await expectOk(response, "Failed to create work record");
   return normalizeWorkRecord(
     (await response.json()) as CreateWorkRecordSuccess,
@@ -103,15 +131,23 @@ export async function fetchCurrentTimerSession() {
   return session ? normalizeTimerSession(session) : null;
 }
 
-export async function createTimerSession(input: CreateTimerSessionRequest) {
-  const response = await apiClient["timer-sessions"].$post({ json: input });
+export async function createTimerSession(
+  input: CreateTimerSessionRequest,
+  idempotencyKey: string,
+) {
+  const response = await apiClient["timer-sessions"].$post(
+    { json: input },
+    { headers: { "Idempotency-Key": idempotencyKey } },
+  );
   await expectOk(response, "Failed to create timer session");
   return normalizeTimerSession(
     (await response.json()) as CreateTimerSessionSuccess,
   );
 }
 
-export async function deleteCurrentTimerSession() {
-  const response = await apiClient["timer-sessions"].$delete();
+export async function deleteCurrentTimerSession(idempotencyKey: string) {
+  const response = await apiClient["timer-sessions"].$delete(undefined, {
+    headers: { "Idempotency-Key": idempotencyKey },
+  });
   await expectOk(response, "Failed to delete timer session");
 }

--- a/apps/web/src/shared/ui/recovery-dialog-provider.tsx
+++ b/apps/web/src/shared/ui/recovery-dialog-provider.tsx
@@ -21,12 +21,14 @@ export function RecoveryDialogProvider({
   const queryClient = useQueryClient();
   const { session, clearSession } = useCurrentTimerSession(initialSession);
 
-  const completeKeyRef = useRef(crypto.randomUUID());
-  const interruptKeyRef = useRef(crypto.randomUUID());
+  // 各ステップ独立のキー（部分失敗時にリトライ可能にする）
+  // updateTask は PUT で自然に冪等なので、リトライ時は新しいキーで再実行可能
+  const completeUpdateKeyRef = useRef(crypto.randomUUID());
+  const completeRecordKeyRef = useRef(crypto.randomUUID());
+  const interruptRecordKeyRef = useRef(crypto.randomUUID());
 
   const handleComplete = useCallback(
     async (activeSession: TimerSession) => {
-      const baseKey = completeKeyRef.current;
       const tasks = await fetchTasks();
       const currentTask = tasks.find(
         (task) => task.id === activeSession.taskId,
@@ -46,8 +48,9 @@ export function RecoveryDialogProvider({
           estimatedMinutes: currentTask.estimatedMinutes,
           scheduledDate: currentTask.scheduledDate,
         },
-        `${baseKey}:update`,
+        completeUpdateKeyRef.current,
       );
+      completeUpdateKeyRef.current = crypto.randomUUID();
       queryClient.setQueryData<Task[]>(queryKeys.tasks, (prev = tasks) =>
         prev.map((task) =>
           task.id === completedTask.id ? completedTask : task,
@@ -64,14 +67,14 @@ export function RecoveryDialogProvider({
           ),
           result: "completed",
         },
-        `${baseKey}:record`,
+        completeRecordKeyRef.current,
       );
+      completeRecordKeyRef.current = crypto.randomUUID();
       queryClient.setQueryData<WorkRecord[]>(
         queryKeys.workRecords,
         (prev = []) => [...prev, createdRecord],
       );
       await clearSession();
-      completeKeyRef.current = crypto.randomUUID();
     },
     [clearSession, queryClient],
   );
@@ -88,14 +91,14 @@ export function RecoveryDialogProvider({
           ),
           result: "interrupted",
         },
-        interruptKeyRef.current,
+        interruptRecordKeyRef.current,
       );
+      interruptRecordKeyRef.current = crypto.randomUUID();
       queryClient.setQueryData<WorkRecord[]>(
         queryKeys.workRecords,
         (prev = []) => [...prev, createdRecord],
       );
       await clearSession();
-      interruptKeyRef.current = crypto.randomUUID();
     },
     [clearSession, queryClient],
   );

--- a/apps/web/src/shared/ui/recovery-dialog-provider.tsx
+++ b/apps/web/src/shared/ui/recovery-dialog-provider.tsx
@@ -50,7 +50,6 @@ export function RecoveryDialogProvider({
         },
         completeUpdateKeyRef.current,
       );
-      completeUpdateKeyRef.current = crypto.randomUUID();
       queryClient.setQueryData<Task[]>(queryKeys.tasks, (prev = tasks) =>
         prev.map((task) =>
           task.id === completedTask.id ? completedTask : task,
@@ -69,12 +68,14 @@ export function RecoveryDialogProvider({
         },
         completeRecordKeyRef.current,
       );
-      completeRecordKeyRef.current = crypto.randomUUID();
       queryClient.setQueryData<WorkRecord[]>(
         queryKeys.workRecords,
         (prev = []) => [...prev, createdRecord],
       );
       await clearSession();
+      // 全ステップ成功後にキーを再生成
+      completeUpdateKeyRef.current = crypto.randomUUID();
+      completeRecordKeyRef.current = crypto.randomUUID();
     },
     [clearSession, queryClient],
   );
@@ -93,12 +94,12 @@ export function RecoveryDialogProvider({
         },
         interruptRecordKeyRef.current,
       );
-      interruptRecordKeyRef.current = crypto.randomUUID();
       queryClient.setQueryData<WorkRecord[]>(
         queryKeys.workRecords,
         (prev = []) => [...prev, createdRecord],
       );
       await clearSession();
+      interruptRecordKeyRef.current = crypto.randomUUID();
     },
     [clearSession, queryClient],
   );

--- a/apps/web/src/shared/ui/recovery-dialog-provider.tsx
+++ b/apps/web/src/shared/ui/recovery-dialog-provider.tsx
@@ -2,7 +2,7 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 
 import { useCurrentTimerSession } from "@/shared/hooks/use-current-timer-session";
 import { calcDurationMinutes } from "@/shared/hooks/use-timer";
@@ -21,8 +21,12 @@ export function RecoveryDialogProvider({
   const queryClient = useQueryClient();
   const { session, clearSession } = useCurrentTimerSession(initialSession);
 
+  const completeKeyRef = useRef(crypto.randomUUID());
+  const interruptKeyRef = useRef(crypto.randomUUID());
+
   const handleComplete = useCallback(
     async (activeSession: TimerSession) => {
+      const baseKey = completeKeyRef.current;
       const tasks = await fetchTasks();
       const currentTask = tasks.find(
         (task) => task.id === activeSession.taskId,
@@ -31,55 +35,67 @@ export function RecoveryDialogProvider({
         throw new Error("Task not found for recovery session");
       }
 
-      const completedTask = await updateTask(activeSession.taskId, {
-        name: currentTask.name,
-        categoryId:
-          currentTask.categoryId === "" ? null : currentTask.categoryId,
-        status: "done",
-        isNext: false,
-        estimatedMinutes: currentTask.estimatedMinutes,
-        scheduledDate: currentTask.scheduledDate,
-      });
+      const completedTask = await updateTask(
+        activeSession.taskId,
+        {
+          name: currentTask.name,
+          categoryId:
+            currentTask.categoryId === "" ? null : currentTask.categoryId,
+          status: "done",
+          isNext: false,
+          estimatedMinutes: currentTask.estimatedMinutes,
+          scheduledDate: currentTask.scheduledDate,
+        },
+        `${baseKey}:update`,
+      );
       queryClient.setQueryData<Task[]>(queryKeys.tasks, (prev = tasks) =>
         prev.map((task) =>
           task.id === completedTask.id ? completedTask : task,
         ),
       );
 
-      const createdRecord = await createWorkRecord({
-        taskId: activeSession.taskId,
-        date: format(new Date(activeSession.startedAt), "yyyy-MM-dd"),
-        durationMinutes: Math.max(
-          1,
-          calcDurationMinutes(activeSession.startedAt),
-        ),
-        result: "completed",
-      });
+      const createdRecord = await createWorkRecord(
+        {
+          taskId: activeSession.taskId,
+          date: format(new Date(activeSession.startedAt), "yyyy-MM-dd"),
+          durationMinutes: Math.max(
+            1,
+            calcDurationMinutes(activeSession.startedAt),
+          ),
+          result: "completed",
+        },
+        `${baseKey}:record`,
+      );
       queryClient.setQueryData<WorkRecord[]>(
         queryKeys.workRecords,
         (prev = []) => [...prev, createdRecord],
       );
       await clearSession();
+      completeKeyRef.current = crypto.randomUUID();
     },
     [clearSession, queryClient],
   );
 
   const handleInterrupt = useCallback(
     async (activeSession: TimerSession) => {
-      const createdRecord = await createWorkRecord({
-        taskId: activeSession.taskId,
-        date: format(new Date(activeSession.startedAt), "yyyy-MM-dd"),
-        durationMinutes: Math.max(
-          1,
-          calcDurationMinutes(activeSession.startedAt),
-        ),
-        result: "interrupted",
-      });
+      const createdRecord = await createWorkRecord(
+        {
+          taskId: activeSession.taskId,
+          date: format(new Date(activeSession.startedAt), "yyyy-MM-dd"),
+          durationMinutes: Math.max(
+            1,
+            calcDurationMinutes(activeSession.startedAt),
+          ),
+          result: "interrupted",
+        },
+        interruptKeyRef.current,
+      );
       queryClient.setQueryData<WorkRecord[]>(
         queryKeys.workRecords,
         (prev = []) => [...prev, createdRecord],
       );
       await clearSession();
+      interruptKeyRef.current = crypto.randomUUID();
     },
     [clearSession, queryClient],
   );


### PR DESCRIPTION
## 概要

Idempotency-Key ヘッダーによるサーバー側の多重リクエスト防止を追加する。
クライアントはアクション単位でキーを生成し、サーバーは同一キーの重複リクエストに対して保存済みレスポンスをリプレイする。

closes #53

## 変更内容

### サーバー側
- `shared/idempotency/middleware.ts`: Idempotency-Key ミドルウェアを新規作成
  - `userId:method:path:key` の composite key で重複を検知
  - 成功レスポンスを保存し、同一キーのリトライでリプレイ（409 ではなく元のレスポンスを返す）
  - 非2xxレスポンス・throw 時はキーを解放しリトライを許可
  - in-memory Map + TTL 5分で管理（**既知の制約**: プロセス再起動やマルチインスタンスでは機能しない。Redis/DB への移行が必要）
- `app.ts`: ミドルウェア適用、CORS に Idempotency-Key を追加
- 統合テスト追加（レスポンスリプレイ、失敗後リトライ等）

### クライアント側
- `index.ts`: 全 mutation 関数に `idempotencyKey` パラメータを追加
- `use-tasks.ts`: 各アクションに `useRef(crypto.randomUUID())` でキーを管理。成功後に再生成
- `use-work-records.ts` / `use-current-timer-session.ts`: 同様のキー管理
- `recovery-dialog-provider.tsx`: 各ステップに独立キー。全ステップ完了後にキーを再生成（部分失敗時のリトライ対応）

## 確認方法

- [x] `pnpm build` が通る
- [x] `pnpm lint` が通る
- [x] `pnpm test` が通る
- [ ] ブラウザで動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
