### PR TITLE
feat: API に構造化ロギング基盤を導入

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,2 +1,5 @@
 DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 SUPABASE_URL="http://127.0.0.1:54321"
+LOG_LEVEL="info"
+LOG_PRETTY="false"
+LOG_SQL="false"

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,4 +2,5 @@ DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 SUPABASE_URL="http://127.0.0.1:54321"
 LOG_LEVEL="info"
 LOG_PRETTY="false"
+# LOG_SQL を有効にするには LOG_LEVEL="debug" も必要
 LOG_SQL="false"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,12 +23,14 @@
     "@todo-list/schema": "workspace:*",
     "hono": "^4.7.0",
     "jose": "^6.2.2",
+    "pino": "^10.3.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",
     "dotenv": "^17.4.2",
     "oxlint": "^1.60.0",
+    "pino-pretty": "^13.1.3",
     "prisma": "^7.7.0",
     "tsx": "^4.19.0",
     "typescript": "^6.0.3",

--- a/apps/api/src/__tests__/helpers/log.ts
+++ b/apps/api/src/__tests__/helpers/log.ts
@@ -1,0 +1,17 @@
+import { Writable } from "node:stream";
+
+export type LogEntry = Record<string, unknown>;
+
+export function createLogCapture(): {
+  logs: LogEntry[];
+  stream: Writable;
+} {
+  const logs: LogEntry[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      logs.push(JSON.parse(chunk.toString()));
+      callback();
+    },
+  });
+  return { logs, stream };
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,10 +1,14 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { requestId } from "hono/request-id";
 import { categoriesRoute } from "./features/categories/route";
 import { tasksRoute } from "./features/tasks/route";
 import { timerSessionsRoute } from "./features/timer-sessions/route";
 import { workRecordsRoute } from "./features/work-records/route";
 import { authMiddleware } from "./shared/auth/middleware";
+import { createErrorHandler } from "./shared/http/error-handler";
+import { createRequestLogger } from "./shared/http/request-logger";
+import { logger } from "./shared/lib/logger";
 
 function resolveCorsOrigin(origin: string) {
   if (origin.startsWith("http://localhost:")) {
@@ -18,7 +22,11 @@ function resolveCorsOrigin(origin: string) {
   return "";
 }
 
+const requestLoggerMiddleware = createRequestLogger(logger);
+const errorHandler = createErrorHandler(logger);
+
 const app = new Hono()
+  .use("/*", requestId())
   .use(
     "/*",
     cors({
@@ -27,11 +35,13 @@ const app = new Hono()
       allowHeaders: ["Content-Type", "Authorization"],
     }),
   )
+  .use("/*", requestLoggerMiddleware)
   .use("/*", authMiddleware)
   .route("/tasks", tasksRoute)
   .route("/categories", categoriesRoute)
   .route("/work-records", workRecordsRoute)
-  .route("/timer-sessions", timerSessionsRoute);
+  .route("/timer-sessions", timerSessionsRoute)
+  .onError(errorHandler);
 
 export default app;
 export type AppType = typeof app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,7 +1,10 @@
 import "dotenv/config";
 import { serve } from "@hono/node-server";
 import app from "./app";
+import { logger } from "./shared/lib/logger";
 
 const PORT = 3001;
 
 serve({ fetch: app.fetch, port: PORT });
+
+logger.info({ port: PORT }, "server started");

--- a/apps/api/src/shared/http/__tests__/error-handler.test.ts
+++ b/apps/api/src/shared/http/__tests__/error-handler.test.ts
@@ -1,0 +1,139 @@
+import { Hono } from "hono";
+import { requestId } from "hono/request-id";
+import { describe, expect, it } from "vitest";
+import type { LogEntry } from "../../../__tests__/helpers/log";
+import { createLogCapture } from "../../../__tests__/helpers/log";
+import { createLogger } from "../../lib/logger";
+import { createErrorHandler } from "../error-handler";
+
+function setupTestApp(): { app: Hono; logs: LogEntry[] } {
+  const { logs, stream } = createLogCapture();
+  const logger = createLogger({ level: "trace", destination: stream });
+  const handler = createErrorHandler(logger);
+
+  const app = new Hono()
+    .use("/*", requestId())
+    .get("/error", () => {
+      throw new Error("テストエラー");
+    })
+    .onError(handler);
+
+  return { app, logs };
+}
+
+describe("createErrorHandler", () => {
+  describe("未捕捉例外のログ出力", () => {
+    it("error レベルで 'unhandled error' メッセージを出力する", async () => {
+      // Given
+      const { app, logs } = setupTestApp();
+
+      // When
+      await app.request("/error");
+
+      // Then
+      expect(logs).toHaveLength(1);
+      expect(logs[0].level).toBe("error");
+      expect(logs[0].msg).toBe("unhandled error");
+    });
+
+    it("err.message を出力する", async () => {
+      // Given
+      const { app, logs } = setupTestApp();
+
+      // When
+      await app.request("/error");
+
+      // Then
+      const err = logs[0].err as Record<string, unknown>;
+      expect(err.message).toBe("テストエラー");
+    });
+
+    it("err.name を出力する", async () => {
+      // Given
+      const { app, logs } = setupTestApp();
+
+      // When
+      await app.request("/error");
+
+      // Then
+      const err = logs[0].err as Record<string, unknown>;
+      expect(err.name).toBe("Error");
+    });
+
+    it("err.stack を出力する", async () => {
+      // Given
+      const { app, logs } = setupTestApp();
+
+      // When
+      await app.request("/error");
+
+      // Then
+      const err = logs[0].err as Record<string, unknown>;
+      expect(typeof err.stack).toBe("string");
+      expect(err.stack as string).toContain("テストエラー");
+    });
+  });
+
+  describe("レスポンス", () => {
+    it("500 ステータスを返す", async () => {
+      // Given
+      const { app } = setupTestApp();
+
+      // When
+      const res = await app.request("/error");
+
+      // Then
+      expect(res.status).toBe(500);
+    });
+
+    it("{ error: 'Internal Server Error' } ボディを返す", async () => {
+      // Given
+      const { app } = setupTestApp();
+
+      // When
+      const res = await app.request("/error");
+      const body = await res.json();
+
+      // Then
+      expect(body).toEqual({ error: "Internal Server Error" });
+    });
+  });
+
+  describe("requestId 伝播", () => {
+    it("requestId がログに含まれる", async () => {
+      // Given
+      const { app, logs } = setupTestApp();
+
+      // When
+      await app.request("/error");
+
+      // Then
+      expect(logs).toHaveLength(1);
+      expect(logs[0].requestId).toBeDefined();
+      expect(typeof logs[0].requestId).toBe("string");
+    });
+  });
+
+  describe("requestId 未設定", () => {
+    it("requestId ミドルウェアなしでもエラーを処理する", async () => {
+      // Given
+      const { logs, stream } = createLogCapture();
+      const logger = createLogger({ level: "trace", destination: stream });
+      const handler = createErrorHandler(logger);
+
+      const app = new Hono()
+        .get("/error", () => {
+          throw new Error("テストエラー");
+        })
+        .onError(handler);
+
+      // When
+      const res = await app.request("/error");
+
+      // Then
+      expect(res.status).toBe(500);
+      expect(logs).toHaveLength(1);
+      expect(logs[0].level).toBe("error");
+    });
+  });
+});

--- a/apps/api/src/shared/http/__tests__/request-logger.test.ts
+++ b/apps/api/src/shared/http/__tests__/request-logger.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { LogEntry } from "../../../__tests__/helpers/log";
 import { createLogCapture } from "../../../__tests__/helpers/log";
 import { createLogger } from "../../lib/logger";
+import { createErrorHandler } from "../error-handler";
 import { createRequestLogger } from "../request-logger";
 
 function setupTestApp(): { app: Hono; logs: LogEntry[] } {
@@ -19,7 +20,11 @@ function setupTestApp(): { app: Hono; logs: LogEntry[] } {
     .get("/server-error", (c) =>
       c.json({ error: "Internal Server Error" }, 500),
     )
-    .post("/data", (c) => c.json({ result: "ok" }));
+    .get("/throw", () => {
+      throw new Error("テストエラー");
+    })
+    .post("/data", (c) => c.json({ result: "ok" }))
+    .onError(createErrorHandler(logger));
 
   return { app, logs };
 }
@@ -74,6 +79,25 @@ describe("createRequestLogger", () => {
       expect(logs[0].level).toBe("error");
       expect(logs[0].status).toBe(500);
       expect(logs[0].msg).toBe("request completed");
+    });
+  });
+
+  describe("ハンドラが例外を throw したケース（onError 経由）", () => {
+    it("error レベルで status 500 の request completed ログを出力する", async () => {
+      // Given
+      const { app, logs } = setupTestApp();
+
+      // When
+      await app.request("/throw");
+
+      // Then
+      const requestLog = logs.find((l) => l.msg === "request completed");
+      expect(requestLog).toBeDefined();
+      expect(requestLog!.level).toBe("error");
+      expect(requestLog!.status).toBe(500);
+      expect(requestLog!.method).toBe("GET");
+      expect(requestLog!.path).toBe("/throw");
+      expect(typeof requestLog!.durationMs).toBe("number");
     });
   });
 

--- a/apps/api/src/shared/http/__tests__/request-logger.test.ts
+++ b/apps/api/src/shared/http/__tests__/request-logger.test.ts
@@ -1,0 +1,98 @@
+import { Hono } from "hono";
+import { requestId } from "hono/request-id";
+import { describe, expect, it } from "vitest";
+import type { LogEntry } from "../../../__tests__/helpers/log";
+import { createLogCapture } from "../../../__tests__/helpers/log";
+import { createLogger } from "../../lib/logger";
+import { createRequestLogger } from "../request-logger";
+
+function setupTestApp(): { app: Hono; logs: LogEntry[] } {
+  const { logs, stream } = createLogCapture();
+  const logger = createLogger({ level: "trace", destination: stream });
+  const middleware = createRequestLogger(logger);
+
+  const app = new Hono()
+    .use("/*", requestId())
+    .use("/*", middleware)
+    .get("/ok", (c) => c.text("ok"))
+    .get("/not-found", (c) => c.json({ error: "Not Found" }, 404))
+    .get("/server-error", (c) =>
+      c.json({ error: "Internal Server Error" }, 500),
+    )
+    .post("/data", (c) => c.json({ result: "ok" }));
+
+  return { app, logs };
+}
+
+describe("createRequestLogger", () => {
+  describe("正常リクエスト（2xx）", () => {
+    it("info レベルで requestId, method, path, status, durationMs を出力する", async () => {
+      // Given
+      const { app, logs } = setupTestApp();
+
+      // When
+      await app.request("/ok");
+
+      // Then
+      expect(logs).toHaveLength(1);
+      expect(logs[0].level).toBe("info");
+      expect(logs[0].requestId).toBeDefined();
+      expect(logs[0].method).toBe("GET");
+      expect(logs[0].path).toBe("/ok");
+      expect(logs[0].status).toBe(200);
+      expect(typeof logs[0].durationMs).toBe("number");
+      expect(logs[0].msg).toBe("request completed");
+    });
+  });
+
+  describe("4xx レスポンス", () => {
+    it("warn レベルで出力する", async () => {
+      // Given
+      const { app, logs } = setupTestApp();
+
+      // When
+      await app.request("/not-found");
+
+      // Then
+      expect(logs).toHaveLength(1);
+      expect(logs[0].level).toBe("warn");
+      expect(logs[0].status).toBe(404);
+      expect(logs[0].msg).toBe("request completed");
+    });
+  });
+
+  describe("5xx レスポンス", () => {
+    it("error レベルで出力する", async () => {
+      // Given
+      const { app, logs } = setupTestApp();
+
+      // When
+      await app.request("/server-error");
+
+      // Then
+      expect(logs).toHaveLength(1);
+      expect(logs[0].level).toBe("error");
+      expect(logs[0].status).toBe(500);
+      expect(logs[0].msg).toBe("request completed");
+    });
+  });
+
+  describe("リクエストボディ", () => {
+    it("リクエストボディをログに含めない", async () => {
+      // Given
+      const { app, logs } = setupTestApp();
+
+      // When
+      await app.request("/data", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ secret: "password123" }),
+      });
+
+      // Then
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).not.toHaveProperty("body");
+      expect(JSON.stringify(logs[0])).not.toContain("password123");
+    });
+  });
+});

--- a/apps/api/src/shared/http/error-handler.ts
+++ b/apps/api/src/shared/http/error-handler.ts
@@ -1,0 +1,16 @@
+import type { ErrorHandler } from "hono";
+import type { Logger } from "pino";
+
+export function createErrorHandler(logger: Logger): ErrorHandler {
+  return (err, c) => {
+    logger.error(
+      {
+        requestId: c.get("requestId"),
+        err,
+      },
+      "unhandled error",
+    );
+
+    return c.json({ error: "Internal Server Error" }, 500);
+  };
+}

--- a/apps/api/src/shared/http/request-logger.ts
+++ b/apps/api/src/shared/http/request-logger.ts
@@ -1,0 +1,29 @@
+import type { MiddlewareHandler } from "hono";
+import type { Logger } from "pino";
+
+function getLogLevel(status: number): "info" | "warn" | "error" {
+  if (status >= 500) return "error";
+  if (status >= 400) return "warn";
+  return "info";
+}
+
+export function createRequestLogger(logger: Logger): MiddlewareHandler {
+  return async (c, next) => {
+    const start = Date.now();
+    await next();
+    const status = c.res.status;
+    const durationMs = Date.now() - start;
+    const level = getLogLevel(status);
+
+    logger[level](
+      {
+        requestId: c.get("requestId"),
+        method: c.req.method,
+        path: c.req.path,
+        status,
+        durationMs,
+      },
+      "request completed",
+    );
+  };
+}

--- a/apps/api/src/shared/lib/__tests__/logger.test.ts
+++ b/apps/api/src/shared/lib/__tests__/logger.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { createLogCapture } from "../../../__tests__/helpers/log";
+import { createLogger } from "../logger";
+
+describe("createLogger", () => {
+  describe("JSON 構造化出力", () => {
+    it("level を文字列ラベルで出力する", () => {
+      // Given
+      const { logs, stream } = createLogCapture();
+      const logger = createLogger({ level: "info", destination: stream });
+
+      // When
+      logger.info("テストメッセージ");
+
+      // Then
+      expect(logs).toHaveLength(1);
+      expect(logs[0].level).toBe("info");
+    });
+
+    it("time を ISO 8601 形式で出力する", () => {
+      // Given
+      const { logs, stream } = createLogCapture();
+      const logger = createLogger({ level: "info", destination: stream });
+
+      // When
+      logger.info("テストメッセージ");
+
+      // Then
+      expect(logs).toHaveLength(1);
+      const time = logs[0].time as string;
+      expect(typeof time).toBe("string");
+      expect(Number.isNaN(Date.parse(time))).toBe(false);
+    });
+
+    it("msg フィールドを出力する", () => {
+      // Given
+      const { logs, stream } = createLogCapture();
+      const logger = createLogger({ level: "info", destination: stream });
+
+      // When
+      logger.info("テストメッセージ");
+
+      // Then
+      expect(logs).toHaveLength(1);
+      expect(logs[0].msg).toBe("テストメッセージ");
+    });
+
+    it("pid と hostname を出力しない", () => {
+      // Given
+      const { logs, stream } = createLogCapture();
+      const logger = createLogger({ level: "info", destination: stream });
+
+      // When
+      logger.info("テストメッセージ");
+
+      // Then
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).not.toHaveProperty("pid");
+      expect(logs[0]).not.toHaveProperty("hostname");
+    });
+  });
+
+  describe("redact", () => {
+    it.each([
+      ["authorization", "Bearer secret-token"],
+      ["cookie", "session=abc123"],
+      ["set-cookie", "session=abc; Path=/"],
+      ["password", "secret123"],
+      ["accessToken", "access-token-value"],
+      ["refreshToken", "refresh-token-value"],
+      ["token", "jwt-value"],
+    ])("%s フィールドを [Redacted] に置換する", (field, value) => {
+      // Given
+      const { logs, stream } = createLogCapture();
+      const logger = createLogger({ level: "info", destination: stream });
+
+      // When
+      logger.info({ [field]: value }, "機密データ");
+
+      // Then
+      expect(logs).toHaveLength(1);
+      expect(logs[0][field]).toBe("[Redacted]");
+    });
+
+    it("ネストされたオブジェクト内の機密フィールドを [Redacted] に置換する", () => {
+      // Given
+      const { logs, stream } = createLogCapture();
+      const logger = createLogger({ level: "info", destination: stream });
+
+      // When
+      logger.info(
+        { headers: { authorization: "Bearer nested-secret" } },
+        "ネストされたヘッダー",
+      );
+
+      // Then
+      const headers = logs[0].headers as Record<string, unknown>;
+      expect(headers.authorization).toBe("[Redacted]");
+    });
+  });
+
+  describe("ログレベルフィルタ", () => {
+    it("level=warn 設定時に info ログが出力されない", () => {
+      // Given
+      const { logs, stream } = createLogCapture();
+      const logger = createLogger({ level: "warn", destination: stream });
+
+      // When
+      logger.info("フィルタされるべきメッセージ");
+
+      // Then
+      expect(logs).toHaveLength(0);
+    });
+
+    it("level=warn 設定時に warn ログが出力される", () => {
+      // Given
+      const { logs, stream } = createLogCapture();
+      const logger = createLogger({ level: "warn", destination: stream });
+
+      // When
+      logger.warn("表示されるべきメッセージ");
+
+      // Then
+      expect(logs).toHaveLength(1);
+      expect(logs[0].level).toBe("warn");
+    });
+
+    it("level=warn 設定時に error ログが出力される", () => {
+      // Given
+      const { logs, stream } = createLogCapture();
+      const logger = createLogger({ level: "warn", destination: stream });
+
+      // When
+      logger.error("エラーメッセージ");
+
+      // Then
+      expect(logs).toHaveLength(1);
+      expect(logs[0].level).toBe("error");
+    });
+  });
+});

--- a/apps/api/src/shared/lib/logger.ts
+++ b/apps/api/src/shared/lib/logger.ts
@@ -1,0 +1,64 @@
+import type { DestinationStream } from "pino";
+import pino from "pino";
+
+const REDACT_PATHS = [
+  "authorization",
+  "cookie",
+  '["set-cookie"]',
+  "password",
+  "accessToken",
+  "refreshToken",
+  "token",
+  "*.authorization",
+  "*.cookie",
+  '*["set-cookie"]',
+  "*.password",
+  "*.accessToken",
+  "*.refreshToken",
+  "*.token",
+];
+
+function serializeError(err: unknown): unknown {
+  if (!err || typeof (err as Record<string, unknown>).message !== "string") {
+    return err;
+  }
+  const e = err as Error;
+  return { message: e.message, name: e.name, stack: e.stack };
+}
+
+type LoggerOptions = {
+  level: string;
+  destination: DestinationStream;
+};
+
+export function createLogger(options: LoggerOptions): pino.Logger {
+  return pino(
+    {
+      level: options.level,
+      base: undefined,
+      timestamp: pino.stdTimeFunctions.isoTime,
+      formatters: {
+        level(label) {
+          return { level: label };
+        },
+      },
+      serializers: {
+        err: serializeError,
+      },
+      redact: REDACT_PATHS,
+    },
+    options.destination,
+  );
+}
+
+function resolveDestination(): DestinationStream {
+  if (process.env.LOG_PRETTY === "true") {
+    return pino.transport({ target: "pino-pretty" });
+  }
+  return pino.destination(1);
+}
+
+export const logger = createLogger({
+  level: process.env.LOG_LEVEL ?? "info",
+  destination: resolveDestination(),
+});

--- a/apps/api/src/shared/lib/prisma.ts
+++ b/apps/api/src/shared/lib/prisma.ts
@@ -1,15 +1,50 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
+import { logger } from "./logger";
+
+const prismaLogger = logger.child({ component: "prisma" });
 
 const globalForPrisma = globalThis as {
   prisma?: PrismaClient;
 };
 
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL,
-});
+function createPrismaClient(): PrismaClient {
+  const adapter = new PrismaPg({
+    connectionString: process.env.DATABASE_URL,
+  });
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient({ adapter });
+  const logDefinitions: Array<{
+    level: "warn" | "error" | "query";
+    emit: "event";
+  }> = [
+    { level: "warn", emit: "event" },
+    { level: "error", emit: "event" },
+  ];
+
+  if (process.env.LOG_SQL === "true") {
+    logDefinitions.push({ level: "query", emit: "event" });
+  }
+
+  const client = new PrismaClient({ adapter, log: logDefinitions });
+
+  client.$on("warn", (e) => {
+    prismaLogger.warn(e.message);
+  });
+
+  client.$on("error", (e) => {
+    prismaLogger.error(e.message);
+  });
+
+  if (process.env.LOG_SQL === "true") {
+    client.$on("query", (e) => {
+      prismaLogger.debug({ durationMs: e.duration }, e.query);
+    });
+  }
+
+  return client;
+}
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient();
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;

--- a/apps/api/src/shared/lib/prisma.ts
+++ b/apps/api/src/shared/lib/prisma.ts
@@ -28,11 +28,11 @@ function createPrismaClient(): PrismaClient {
   const client = new PrismaClient({ adapter, log: logDefinitions });
 
   client.$on("warn", (e) => {
-    prismaLogger.warn(e.message);
+    prismaLogger.warn({ target: e.target }, e.message);
   });
 
   client.$on("error", (e) => {
-    prismaLogger.error(e.message);
+    prismaLogger.error({ target: e.target }, e.message);
   });
 
   if (process.env.LOG_SQL === "true") {

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -38,6 +38,8 @@ export default defineConfig(() => {
       env: {
         ...env,
         LOG_LEVEL: "silent",
+        LOG_PRETTY: "false",
+        LOG_SQL: "false",
       },
     },
   };

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -35,7 +35,10 @@ export default defineConfig(() => {
     test: {
       fileParallelism: false,
       globals: true,
-      env,
+      env: {
+        ...env,
+        LOG_LEVEL: "silent",
+      },
     },
   };
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       jose:
         specifier: ^6.2.2
         version: 6.2.2
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -54,6 +57,9 @@ importers:
       oxlint:
         specifier: ^1.60.0
         version: 1.60.0(oxlint-tsgolint@0.21.1)
+      pino-pretty:
+        specifier: ^13.1.3
+        version: 13.1.3
       prisma:
         specifier: ^7.7.0
         version: 7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
@@ -1134,6 +1140,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@prisma/adapter-pg@7.7.0':
     resolution: {integrity: sha512-q33Ta8sKbgzEpAy0lx45tAq//yMv0qcb+8nj+TCA3P4wiAY+OBFEFk/NDkZncAfHaNJeGo5WJpJdpbL+ijYx8g==}
@@ -2356,6 +2365,10 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
@@ -2493,6 +2506,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
@@ -2576,6 +2592,9 @@ packages:
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2691,6 +2710,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
@@ -2786,12 +2808,18 @@ packages:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
 
+  fast-copy@4.0.3:
+    resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -2944,6 +2972,9 @@ packages:
 
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   hono@4.12.14:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
@@ -3101,6 +3132,10 @@ packages:
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3475,6 +3510,10 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -3602,6 +3641,20 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -3674,6 +3727,9 @@ packages:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -3684,6 +3740,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3698,6 +3757,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
@@ -3783,6 +3845,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
@@ -3840,6 +3906,10 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -3849,6 +3919,9 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3920,6 +3993,9 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3993,6 +4069,10 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -4031,6 +4111,10 @@ packages:
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
+
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -5115,6 +5199,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.60.0':
     optional: true
+
+  '@pinojs/redact@0.4.0': {}
 
   '@prisma/adapter-pg@7.7.0':
     dependencies:
@@ -6376,6 +6462,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  atomic-sleep@1.0.0: {}
+
   aws-ssl-profiles@1.1.2: {}
 
   balanced-match@4.0.4: {}
@@ -6513,6 +6601,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.20: {}
+
   commander@11.1.0: {}
 
   commander@14.0.3: {}
@@ -6576,6 +6666,8 @@ snapshots:
   date-fns-jalali@4.1.0-0: {}
 
   date-fns@4.1.0: {}
+
+  dateformat@4.6.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -6651,6 +6743,10 @@ snapshots:
   empathic@2.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -6797,6 +6893,8 @@ snapshots:
     dependencies:
       pure-rand: 6.1.0
 
+  fast-copy@4.0.3: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -6806,6 +6904,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-safe-stringify@2.1.1: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -6956,6 +7056,8 @@ snapshots:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.0
 
+  help-me@5.0.0: {}
+
   hono@4.12.14: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
@@ -7068,6 +7170,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@6.2.2: {}
+
+  joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -7393,6 +7497,8 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -7538,6 +7644,42 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.3
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.4
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 5.0.3
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
+
   pkce-challenge@5.0.1: {}
 
   pkg-types@2.3.0:
@@ -7608,6 +7750,8 @@ snapshots:
 
   proc-log@6.1.0: {}
 
+  process-warning@5.0.0: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -7624,6 +7768,11 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
@@ -7633,6 +7782,8 @@ snapshots:
       side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -7761,6 +7912,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  real-require@0.2.0: {}
+
   recast@0.23.11:
     dependencies:
       ast-types: 0.16.1
@@ -7842,6 +7995,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -7849,6 +8004,8 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
+
+  secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
 
@@ -8003,6 +8160,10 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
@@ -8059,6 +8220,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-json-comments@5.0.3: {}
+
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.5):
     dependencies:
       client-only: 0.0.1
@@ -8092,6 +8255,10 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
 
   tiny-invariant@1.3.3: {}
 


### PR DESCRIPTION
## 概要

API に Pino ベースの構造化ロギング基盤を導入し、リクエスト追跡・エラー記録・Prisma ログ統合・機密情報 redact・環境変数制御を実現する。

closes #49

## 変更内容

- Pino ベースの共通ロガー（`shared/lib/logger.ts`）を追加。JSON構造化出力、ISO 8601 タイムスタンプ、機密情報 redact、ログレベル文字列化
- リクエストロギングミドルウェア（`shared/http/request-logger.ts`）を追加。requestId, method, path, status, durationMs を出力（2xx=info, 4xx=warn, 5xx=error）
- グローバルエラーハンドラ（`shared/http/error-handler.ts`）を追加。未捕捉例外の構造化ログ + 500 レスポンス返却
- `app.ts` にミドルウェア配線: `requestId()` → `cors()` → requestLogger → authMiddleware、`.onError(errorHandler)` 追加
- Prisma の warn/error ログを Pino に統合。`LOG_SQL=true` で query ログ有効化
- サーバー起動ログを追加
- 環境変数 `LOG_LEVEL`, `LOG_PRETTY`, `LOG_SQL` を追加
- テスト時 `LOG_LEVEL=silent` でログ出力を抑制
- ロガー・ミドルウェアの単体テスト（26テスト）を追加

## 確認方法

- [x] `pnpm build` が通る
- [x] `pnpm lint` が通る
- [x] `pnpm test` が通る（78テスト全パス）
- [ ] ブラウザで動作確認済み
