### PR TITLE
Add form validation harness and lint rules

### DIFF
--- a/.agent-rules/web/form-validation.md
+++ b/.agent-rules/web/form-validation.md
@@ -1,0 +1,60 @@
+---
+paths:
+  - "apps/web/src/**/*.ts"
+  - "apps/web/src/**/*.tsx"
+  - "packages/schema/src/**/*.ts"
+---
+
+# Web フォームバリデーションルール
+
+フォームのバリデーションは「共通ルール」と「UI 入力都合」を分離すること。
+
+## 基本方針
+
+- 必須、文字数、数値範囲、enum、HEX、UUID、日付フォーマットのような本質的な制約は `packages/schema` に寄せる
+- `trim`, `"" -> null`, `Date`, `<select>` の string 値のような UI 入力都合は `apps/web` 側で扱う
+- UI 用 schema はフォーム近傍に置き、shared primitive schema に寄せる
+
+## react-hook-form
+
+- フォーム状態管理は `react-hook-form` を使う
+- バリデーションは `zodResolver` を使う
+- submit ボタンは `LoadingButton` を使う
+- 多重送信防止は `mutation-guard.md` に従う
+
+## submit / mutation の責務
+
+- フォームコンポーネント
+  - 入力 UI
+  - RHF
+  - schema
+  - フィールドエラー表示
+- カスタム hook
+  - submit
+  - mutation 呼び出し
+  - API エラー → `setError`
+  - 成功時の close / redirect
+
+バリデーションルール本体を submit hook に書かないこと。
+
+## API エラーの扱い
+
+- API の field error は可能な限り `setError` に流す
+- フィールドに割り当てられないエラーは `root.serverError` に出す
+
+## 認証フォームの扱い
+
+- Supabase など API 契約を共有していないフォームは `apps/web` 側だけで schema を持ってよい
+- ただし、同じフォーム内では UI 用 schema と submit hook の責務分離は守る
+
+## 配置ルール
+
+- 1 つのページでしか使わないフォームは `views/**/ui/`
+- 複数ページで使うフォームは `shared/ui/`
+- schema と submit hook はフォームの近くに置く
+
+## 避けること
+
+- 同じ `min`, `max`, `positive` を API と Web で二重定義する
+- API 契約 schema を UI 入力 schema としてそのまま使う
+- `useState` だけでフォーム状態・エラー・submit を個別管理し続ける

--- a/.agent-rules/web/mutation-guard.md
+++ b/.agent-rules/web/mutation-guard.md
@@ -27,8 +27,23 @@ paths:
 const handleSubmit = async (e: React.SubmitEvent<HTMLFormElement>) => {
   e.preventDefault();
   if (loading) return;
-  await onSubmit(data);
+await onSubmit(data);
 };
+```
+
+### react-hook-form を使う場合
+
+- `formState.isSubmitting` を `loading` 変数に束縛して使ってよい
+- submit ボタンには `LoadingButton loading={loading}` を渡す
+- `handleSubmit(async (values) => { if (loading) return; ... })` の形で明示ガードを残す
+
+```tsx
+const loading = isSubmitting;
+
+const onSubmit = handleSubmit(async (values) => {
+  if (loading) return;
+  await submit(values);
+});
 ```
 
 ## 複合操作（複数の非同期処理 + 画面遷移）

--- a/.agent-rules/web/test-coverage.md
+++ b/.agent-rules/web/test-coverage.md
@@ -2,24 +2,21 @@
 paths:
   - "apps/web/src/shared/hooks/**"
   - "apps/web/src/shared/lib/**"
+  - "apps/web/src/shared/ui/**"
+  - "apps/web/src/views/**"
 ---
 
 # Web テストルール
 
-## テスト必須ディレクトリ
+## 何をテストするか
 
-以下のディレクトリのファイルを追加・変更した場合、対応するテストを書くこと。
-
-- `apps/web/src/shared/hooks/` — カスタムフック
-- `apps/web/src/shared/lib/` — ユーティリティ関数（`api/`, `supabase/` 配下は除く）
-
-## テスト不要
-
-- `apps/web/src/app/` — Next.js ルーティング層
-- `apps/web/src/views/` — ページコンポーネント
-- `apps/web/src/shared/ui/` — UI コンポーネント
+- `apps/web/src/shared/hooks/` のカスタムフックはテスト必須
+- `apps/web/src/shared/lib/` のユーティリティ関数はテスト必須（`api/`, `supabase/` を除く）
+- `shared/ui/` や `views/**/ui/` のうち、フォーム、バリデーション、状態遷移、submit、エラー表示を持つものはテスト対象
+- `app/` のルーティング層や、見た目だけの UI は原則テスト不要
 
 ## 規約
 
-- テストファイルは `__tests__/` ディレクトリに `<対象ファイル名>.test.ts(x)` で配置する
+- テストファイルは `__tests__/` ディレクトリに置く
+- 実装ファイルの隣に `.test.ts(x)` を colocate しない
 - テストランナー: Vitest

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,4 @@
+approval_policy = "never"
 [features]
 codex_hooks = true
 

--- a/apps/api/.oxlintrc.json
+++ b/apps/api/.oxlintrc.json
@@ -5,6 +5,7 @@
     "correctness": "error"
   },
   "rules": {
+    "typescript/no-deprecated": "error",
     "typescript/switch-exhaustiveness-check": "error"
   },
   "overrides": [

--- a/apps/web/.oxlintrc.json
+++ b/apps/web/.oxlintrc.json
@@ -15,8 +15,20 @@
   "ignorePatterns": ["src/shared/ui/shadcn/**"],
   "rules": {
     "react-hooks/exhaustive-deps": "warn",
+    "typescript/no-deprecated": "error",
     "typescript/switch-exhaustiveness-check": "error",
     "react/no-multi-comp": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          {
+            "group": ["next/font/google"],
+            "message": "next/font/google は使用しないでください。system font または local font を使ってください"
+          }
+        ]
+      }
+    ],
     "nextjs/google-font-display": "error",
     "nextjs/google-font-preconnect": "error",
     "nextjs/no-css-tags": "error",
@@ -31,6 +43,10 @@
           "error",
           {
             "patterns": [
+              {
+                "group": ["next/font/google"],
+                "message": "next/font/google は使用しないでください。system font または local font を使ってください"
+              },
               {
                 "group": ["@/views/*", "@/views/**"],
                 "message": "shared/ から views/ への import は禁止です（FSD依存方向: app → views → shared）"
@@ -52,6 +68,10 @@
           {
             "patterns": [
               {
+                "group": ["next/font/google"],
+                "message": "next/font/google は使用しないでください。system font または local font を使ってください"
+              },
+              {
                 "group": ["@/views/*", "@/views/**"],
                 "message": "views/ 同士の cross-import は禁止です。共通化するなら shared/ に移動してください"
               },
@@ -71,6 +91,10 @@
           "error",
           {
             "patterns": [
+              {
+                "group": ["next/font/google"],
+                "message": "next/font/google は使用しないでください。system font または local font を使ってください"
+              },
               {
                 "group": ["@/views/*/*", "@/views/*/**"],
                 "message": "views/ の内部ファイルを直接 import しないでください。index.ts (Public API) 経由で import してください"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.3",
     "@tanstack/react-query": "^5.0.0",
@@ -28,8 +29,10 @@
     "react": "19.2.5",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.5",
+    "react-hook-form": "^7.73.1",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -5,7 +5,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-inter);
+  --font-sans: var(--app-font-sans);
   /* Card / Popover */
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
@@ -47,6 +47,10 @@
 
 :root {
   --radius: 1.5rem;
+  --app-font-sans:
+    "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic UI", "Yu Gothic",
+    "Meiryo", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
 
   /* === Base === */
   --background: #ffffff;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,16 +1,10 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import { Toaster } from "sonner";
 import { getCurrentTimerSession } from "@/shared/lib/api/server";
 import { createSupabaseServerClient } from "@/shared/lib/supabase/server";
 import { AppQueryProvider } from "@/shared/providers/query-provider";
 import { RecoveryDialogProvider } from "@/shared/ui/recovery-dialog-provider";
 import "./globals.css";
-
-const inter = Inter({
-  subsets: ["latin"],
-  variable: "--font-inter",
-});
 
 export const metadata: Metadata = {
   title: "タスク管理",
@@ -33,7 +27,7 @@ export default async function RootLayout({
 
   return (
     <html lang="ja">
-      <body className={`${inter.variable} font-sans antialiased`}>
+      <body className="font-sans antialiased">
         <AppQueryProvider>
           {children}
           {user && (

--- a/apps/web/src/shared/lib/api/errors.ts
+++ b/apps/web/src/shared/lib/api/errors.ts
@@ -1,4 +1,4 @@
-import type { ApiErrorResponse } from "@todo-list/schema";
+import type { ApiErrorResponse, ApiFieldError } from "@todo-list/schema";
 
 export class ApiError extends Error {
   status: number;
@@ -21,6 +21,18 @@ export class ApiError extends Error {
       return (this.body as ApiErrorResponse).message;
     }
     return this.message || "エラーが発生しました";
+  }
+
+  get fieldErrors(): ApiFieldError[] {
+    if (
+      this.body &&
+      typeof this.body === "object" &&
+      "errors" in this.body &&
+      Array.isArray((this.body as ApiErrorResponse).errors)
+    ) {
+      return (this.body as ApiErrorResponse).errors ?? [];
+    }
+    return [];
   }
 }
 

--- a/apps/web/src/shared/lib/forms/__tests__/apply-api-field-errors.test.ts
+++ b/apps/web/src/shared/lib/forms/__tests__/apply-api-field-errors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { applyApiFieldErrors } from "../apply-api-field-errors";
+
+describe("applyApiFieldErrors", () => {
+  it("対応する fieldMap があるエラーだけ setError に流す", () => {
+    const setError = vi.fn();
+
+    const handled = applyApiFieldErrors(
+      [
+        { field: "name", message: "名前は必須です" },
+        { field: "unknown", message: "unknown" },
+      ],
+      setError,
+      { name: "name" },
+    );
+
+    expect(handled).toBe(true);
+    expect(setError).toHaveBeenCalledTimes(1);
+    expect(setError).toHaveBeenCalledWith("name", {
+      type: "server",
+      message: "名前は必須です",
+    });
+  });
+
+  it("対応する fieldMap がなければ false を返す", () => {
+    const setError = vi.fn();
+
+    const handled = applyApiFieldErrors(
+      [{ field: "name", message: "名前は必須です" }],
+      setError,
+      { color: "color" },
+    );
+
+    expect(handled).toBe(false);
+    expect(setError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/shared/lib/forms/apply-api-field-errors.ts
+++ b/apps/web/src/shared/lib/forms/apply-api-field-errors.ts
@@ -1,0 +1,23 @@
+import type { ApiFieldError } from "@todo-list/schema";
+import type { FieldPath, FieldValues, UseFormSetError } from "react-hook-form";
+
+export function applyApiFieldErrors<TFieldValues extends FieldValues>(
+  errors: readonly ApiFieldError[],
+  setError: UseFormSetError<TFieldValues>,
+  fieldMap: Partial<Record<string, FieldPath<TFieldValues>>> = {},
+) {
+  let handled = false;
+
+  for (const error of errors) {
+    const field = fieldMap[error.field];
+    if (!field) continue;
+
+    setError(field, {
+      type: "server",
+      message: error.message,
+    });
+    handled = true;
+  }
+
+  return handled;
+}

--- a/apps/web/src/shared/ui/__tests__/add-task-form.test.tsx
+++ b/apps/web/src/shared/ui/__tests__/add-task-form.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { API_ERROR_CODES } from "@todo-list/schema";
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/shared/lib/api/errors";
+import type { Category } from "@/shared/types/task";
+import { AddTaskModal } from "../add-task-modal";
+
+const categories: Category[] = [
+  { id: "category-1", name: "開発", color: "#3B82F6" },
+];
+
+function renderAddTaskForm(
+  props: Partial<ComponentProps<typeof AddTaskModal>> = {},
+) {
+  const onClose = props.onClose ?? vi.fn();
+  const onSubmit = props.onSubmit ?? vi.fn().mockResolvedValue(undefined);
+  const onCreateCategory =
+    props.onCreateCategory ?? vi.fn().mockResolvedValue("created-category-id");
+
+  render(
+    <AddTaskModal
+      open
+      onClose={onClose}
+      onSubmit={onSubmit}
+      onCreateCategory={onCreateCategory}
+      categories={categories}
+      {...props}
+    />,
+  );
+
+  return { onClose, onSubmit, onCreateCategory };
+}
+
+describe("AddTaskForm", () => {
+  it("空のタスク名では送信せずエラーを表示する", async () => {
+    const user = userEvent.setup();
+    const { onSubmit, onClose } = renderAddTaskForm();
+
+    await user.click(screen.getByRole("button", { name: "追加" }));
+
+    expect(await screen.findByText("タスク名を入力してください")).toBeVisible();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("成功時に整形した値を送信して閉じる", async () => {
+    const user = userEvent.setup();
+    const { onSubmit, onClose } = renderAddTaskForm();
+
+    await user.type(
+      screen.getByPlaceholderText("タスク名を入力"),
+      "  記事を書く  ",
+    );
+    await user.selectOptions(screen.getByRole("combobox"), "30");
+    await user.click(screen.getByRole("button", { name: "追加" }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({
+        name: "記事を書く",
+        categoryId: "",
+        scheduledDate: null,
+        estimatedMinutes: 30,
+      }),
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("API の field error を表示して閉じない", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderAddTaskForm({
+      onSubmit: vi.fn().mockRejectedValue(
+        new ApiError("Failed to create task", 400, {
+          code: API_ERROR_CODES.VALIDATION_ERROR,
+          message: "入力内容に誤りがあります",
+          errors: [{ field: "name", message: "同名のタスクは作成できません" }],
+        }),
+      ),
+    });
+
+    await user.type(
+      screen.getByPlaceholderText("タスク名を入力"),
+      "記事を書く",
+    );
+    await user.click(screen.getByRole("button", { name: "追加" }));
+
+    expect(
+      await screen.findByText("同名のタスクは作成できません"),
+    ).toBeVisible();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/shared/ui/add-task-form-schema.ts
+++ b/apps/web/src/shared/ui/add-task-form-schema.ts
@@ -1,0 +1,11 @@
+import { estimatedMinutesSchema, taskNameSchema } from "@todo-list/schema";
+import { z } from "zod";
+
+export const addTaskFormSchema = z.object({
+  name: z.string().trim().pipe(taskNameSchema),
+  categoryId: z.string(),
+  scheduledDate: z.date().optional(),
+  estimatedMinutes: estimatedMinutesSchema,
+});
+
+export type AddTaskFormValues = z.infer<typeof addTaskFormSchema>;

--- a/apps/web/src/shared/ui/add-task-form.tsx
+++ b/apps/web/src/shared/ui/add-task-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { format, parse } from "date-fns";
-import { useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { parse } from "date-fns";
+import { Controller, useForm } from "react-hook-form";
 
 import type { Category } from "@/shared/types/task";
 import { CategorySelect } from "@/shared/ui/category-select";
@@ -16,7 +17,12 @@ import {
 import { Input } from "@/shared/ui/shadcn/input";
 import { Label } from "@/shared/ui/shadcn/label";
 import { SelectField } from "@/shared/ui/shadcn/select-field";
+import {
+  type AddTaskFormValues,
+  addTaskFormSchema,
+} from "./add-task-form-schema";
 import type { TaskFormData } from "./add-task-modal";
+import { useAddTaskFormSubmit } from "./use-add-task-form-submit";
 
 const ESTIMATED_MINUTES_OPTIONS = [
   { label: "15分", value: 15 },
@@ -45,90 +51,125 @@ export function AddTaskForm({
   editingTask,
   loading = false,
 }: AddTaskFormProps) {
-  const [name, setName] = useState(editingTask?.name ?? "");
-  const [categoryId, setCategoryId] = useState(editingTask?.categoryId ?? "");
-  const [scheduledDate, setScheduledDate] = useState<Date | undefined>(
-    editingTask?.scheduledDate
-      ? parse(editingTask.scheduledDate, "yyyy-MM-dd", new Date())
-      : undefined,
-  );
-  const [estimatedMinutes, setEstimatedMinutes] = useState<number | null>(
-    editingTask?.estimatedMinutes ?? null,
-  );
-  const [nameError, setNameError] = useState(false);
-
-  const handleSubmit = async (e: React.SubmitEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (loading) return;
-    if (!name.trim()) {
-      setNameError(true);
-      return;
-    }
-
-    await onSubmit({
-      name: name.trim(),
-      categoryId,
-      scheduledDate: scheduledDate ? format(scheduledDate, "yyyy-MM-dd") : null,
-      estimatedMinutes,
-    });
-    onClose();
-  };
+  const {
+    control,
+    formState: { errors },
+    handleSubmit,
+    register,
+    setError,
+  } = useForm<AddTaskFormValues>({
+    resolver: zodResolver(addTaskFormSchema),
+    defaultValues: {
+      name: editingTask?.name ?? "",
+      categoryId: editingTask?.categoryId ?? "",
+      scheduledDate: editingTask?.scheduledDate
+        ? parse(editingTask.scheduledDate, "yyyy-MM-dd", new Date())
+        : undefined,
+      estimatedMinutes: editingTask?.estimatedMinutes ?? null,
+    },
+  });
+  const submitTaskForm = useAddTaskFormSubmit({
+    onSubmit,
+    onSuccess: onClose,
+    setError,
+  });
 
   const isEditing = !!editingTask;
+  const onFormSubmit = handleSubmit(async (values) => {
+    if (loading) return;
+    await submitTaskForm(values);
+  });
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={onFormSubmit} noValidate>
       <DialogHeader>
         <DialogTitle>{isEditing ? "タスク編集" : "タスク追加"}</DialogTitle>
       </DialogHeader>
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-1.5">
-          <Label className="text-sm font-medium">
+          <Label htmlFor="task-name" className="text-sm font-medium">
             タスク名<span className="text-destructive">*</span>
           </Label>
           <Input
+            id="task-name"
             placeholder="タスク名を入力"
-            value={name}
-            onChange={(e) => {
-              setName(e.target.value);
-              if (e.target.value.trim()) setNameError(false);
-            }}
-            aria-invalid={nameError}
+            aria-invalid={!!errors.name}
+            disabled={loading}
+            {...register("name")}
           />
-          {nameError && (
+          {errors.name?.message && (
             <span className="text-xs text-destructive">
-              タスク名を入力してください
+              {errors.name.message}
             </span>
           )}
         </div>
 
-        <CategorySelect
-          categories={categories}
-          selectedCategoryId={categoryId}
-          onSelect={setCategoryId}
-          onCreateCategory={onCreateCategory}
+        <Controller
+          control={control}
+          name="categoryId"
+          render={({ field }) => (
+            <CategorySelect
+              categories={categories}
+              selectedCategoryId={field.value}
+              onSelect={field.onChange}
+              onCreateCategory={onCreateCategory}
+            />
+          )}
         />
+        {errors.categoryId?.message && (
+          <span className="text-xs text-destructive">
+            {errors.categoryId.message}
+          </span>
+        )}
 
         <div className="flex flex-col gap-1.5">
           <Label className="text-sm font-medium">予定日</Label>
-          <DatePickerField value={scheduledDate} onChange={setScheduledDate} />
+          <Controller
+            control={control}
+            name="scheduledDate"
+            render={({ field }) => (
+              <DatePickerField value={field.value} onChange={field.onChange} />
+            )}
+          />
+          {errors.scheduledDate?.message && (
+            <span className="text-xs text-destructive">
+              {errors.scheduledDate.message}
+            </span>
+          )}
         </div>
 
         <div className="flex flex-col gap-1.5">
           <Label className="text-sm font-medium">見積もり時間</Label>
-          <SelectField
-            value={estimatedMinutes}
-            onChange={(v) => setEstimatedMinutes(v ? Number(v) : null)}
-            options={ESTIMATED_MINUTES_OPTIONS}
+          <Controller
+            control={control}
+            name="estimatedMinutes"
+            render={({ field }) => (
+              <SelectField
+                value={field.value}
+                onChange={(v) => field.onChange(v ? Number(v) : null)}
+                options={ESTIMATED_MINUTES_OPTIONS}
+              />
+            )}
           />
+          {errors.estimatedMinutes?.message && (
+            <span className="text-xs text-destructive">
+              {errors.estimatedMinutes.message}
+            </span>
+          )}
         </div>
       </div>
+      {errors.root?.serverError?.message && (
+        <p className="text-sm text-destructive">
+          {errors.root.serverError.message}
+        </p>
+      )}
       <DialogFooter className="flex-row gap-2">
         <Button
           type="button"
           variant="outline"
           onClick={onClose}
           className="flex-1"
+          disabled={loading}
         >
           キャンセル
         </Button>

--- a/apps/web/src/shared/ui/use-add-task-form-submit.ts
+++ b/apps/web/src/shared/ui/use-add-task-form-submit.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { format } from "date-fns";
+import { useCallback } from "react";
+import type { UseFormSetError } from "react-hook-form";
+import { ApiError } from "@/shared/lib/api/errors";
+import { applyApiFieldErrors } from "@/shared/lib/forms/apply-api-field-errors";
+import type { AddTaskFormValues } from "./add-task-form-schema";
+import type { TaskFormData } from "./add-task-modal";
+
+interface UseAddTaskFormSubmitParams {
+  onSubmit: (data: TaskFormData) => Promise<void>;
+  onSuccess: () => void;
+  setError: UseFormSetError<AddTaskFormValues>;
+}
+
+function toTaskFormData(values: AddTaskFormValues): TaskFormData {
+  return {
+    name: values.name,
+    categoryId: values.categoryId,
+    scheduledDate: values.scheduledDate
+      ? format(values.scheduledDate, "yyyy-MM-dd")
+      : null,
+    estimatedMinutes: values.estimatedMinutes,
+  };
+}
+
+export function useAddTaskFormSubmit({
+  onSubmit,
+  onSuccess,
+  setError,
+}: UseAddTaskFormSubmitParams) {
+  return useCallback(
+    async (values: AddTaskFormValues) => {
+      try {
+        await onSubmit(toTaskFormData(values));
+        onSuccess();
+      } catch (error) {
+        if (error instanceof ApiError) {
+          const handled = applyApiFieldErrors(error.fieldErrors, setError, {
+            name: "name",
+            categoryId: "categoryId",
+            scheduledDate: "scheduledDate",
+            estimatedMinutes: "estimatedMinutes",
+          });
+
+          if (!handled) {
+            setError("root.serverError", {
+              type: "server",
+              message: error.errorMessage,
+            });
+          }
+          return;
+        }
+
+        throw error;
+      }
+    },
+    [onSubmit, onSuccess, setError],
+  );
+}

--- a/apps/web/src/views/auth/ui/__tests__/auth-form.test.tsx
+++ b/apps/web/src/views/auth/ui/__tests__/auth-form.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthForm } from "../auth-form";
+
+const push = vi.fn();
+const refresh = vi.fn();
+const signInWithPassword = vi.fn();
+const signUp = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push,
+    refresh,
+  }),
+}));
+
+vi.mock("@/shared/lib/supabase/client", () => ({
+  createSupabaseBrowserClient: () => ({
+    auth: {
+      signInWithPassword,
+      signUp,
+    },
+  }),
+}));
+
+describe("AuthForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("空のメールアドレスでは必須エラーを表示する", async () => {
+    const user = userEvent.setup();
+
+    render(<AuthForm mode="login" />);
+
+    await user.type(screen.getByLabelText("パスワード"), "123456");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    expect(
+      await screen.findByText("メールアドレスを入力してください"),
+    ).toBeVisible();
+    expect(signInWithPassword).not.toHaveBeenCalled();
+  });
+
+  it("不正なメールアドレスでは送信しない", async () => {
+    const user = userEvent.setup();
+
+    render(<AuthForm mode="login" />);
+
+    await user.type(screen.getByLabelText("メールアドレス"), "invalid");
+    await user.type(screen.getByLabelText("パスワード"), "123456");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    expect(
+      await screen.findByText("メールアドレスを正しく入力してください"),
+    ).toBeVisible();
+    expect(signInWithPassword).not.toHaveBeenCalled();
+  });
+
+  it("ログイン成功時にトップへ遷移する", async () => {
+    const user = userEvent.setup();
+    signInWithPassword.mockResolvedValue({ error: null });
+
+    render(<AuthForm mode="login" />);
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "mail@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "123456");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    await waitFor(() =>
+      expect(signInWithPassword).toHaveBeenCalledWith({
+        email: "mail@example.com",
+        password: "123456",
+      }),
+    );
+    expect(push).toHaveBeenCalledWith("/");
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it("Supabase エラーを表示する", async () => {
+    const user = userEvent.setup();
+    signUp.mockResolvedValue({
+      error: { message: "Email rate limit exceeded" },
+    });
+
+    render(<AuthForm mode="signup" />);
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "mail@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "123456");
+    await user.click(screen.getByRole("button", { name: "アカウント作成" }));
+
+    expect(await screen.findByText("Email rate limit exceeded")).toBeVisible();
+  });
+});

--- a/apps/web/src/views/auth/ui/auth-form-schema.ts
+++ b/apps/web/src/views/auth/ui/auth-form-schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const authFormSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .min(1, "メールアドレスを入力してください")
+    .pipe(z.email({ error: "メールアドレスを正しく入力してください" })),
+  password: z
+    .string()
+    .min(6, "パスワードは6文字以上で入力してください")
+    .max(72, "パスワードは72文字以内で入力してください"),
+});
+
+export type AuthFormValues = z.infer<typeof authFormSchema>;

--- a/apps/web/src/views/auth/ui/auth-form.tsx
+++ b/apps/web/src/views/auth/ui/auth-form.tsx
@@ -1,12 +1,14 @@
 "use client";
 
+import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { createSupabaseBrowserClient } from "@/shared/lib/supabase/client";
-import { Button } from "@/shared/ui/shadcn/button";
+import { useForm } from "react-hook-form";
+import { LoadingButton } from "@/shared/ui/loading-button";
 import { Input } from "@/shared/ui/shadcn/input";
 import { Label } from "@/shared/ui/shadcn/label";
+import { type AuthFormValues, authFormSchema } from "./auth-form-schema";
+import { useAuthFormSubmit } from "./use-auth-form-submit";
 
 type Props = {
   mode: "login" | "signup";
@@ -14,33 +16,34 @@ type Props = {
 
 export function AuthForm({ mode }: Props) {
   const router = useRouter();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
+  const {
+    formState: { errors, isSubmitting },
+    handleSubmit,
+    register,
+    setError,
+  } = useForm<AuthFormValues>({
+    resolver: zodResolver(authFormSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
 
   const isLogin = mode === "login";
+  const loading = isSubmitting;
+  const submitAuthForm = useAuthFormSubmit({
+    isLogin,
+    onSuccess: () => {
+      router.push("/");
+      router.refresh();
+    },
+    setError,
+  });
 
-  async function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setError("");
-    setLoading(true);
-
-    const supabase = createSupabaseBrowserClient();
-
-    const { error: authError } = isLogin
-      ? await supabase.auth.signInWithPassword({ email, password })
-      : await supabase.auth.signUp({ email, password });
-
-    if (authError) {
-      setError(authError.message);
-      setLoading(false);
-      return;
-    }
-
-    router.push("/");
-    router.refresh();
-  }
+  const onSubmit = handleSubmit(async (values) => {
+    if (loading) return;
+    await submitAuthForm(values);
+  });
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
@@ -49,17 +52,20 @@ export function AuthForm({ mode }: Props) {
           {isLogin ? "ログイン" : "アカウント作成"}
         </h1>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={onSubmit} className="space-y-4" noValidate>
           <div className="space-y-2">
             <Label htmlFor="email">メールアドレス</Label>
             <Input
               id="email"
               type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
               placeholder="mail@example.com"
-              required
+              aria-invalid={!!errors.email}
+              disabled={loading}
+              {...register("email")}
             />
+            {errors.email?.message && (
+              <p className="text-sm text-destructive">{errors.email.message}</p>
+            )}
           </div>
 
           <div className="space-y-2">
@@ -67,19 +73,27 @@ export function AuthForm({ mode }: Props) {
             <Input
               id="password"
               type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
               placeholder="6文字以上"
-              minLength={6}
-              required
+              aria-invalid={!!errors.password}
+              disabled={loading}
+              {...register("password")}
             />
+            {errors.password?.message && (
+              <p className="text-sm text-destructive">
+                {errors.password.message}
+              </p>
+            )}
           </div>
 
-          {error && <p className="text-sm text-destructive">{error}</p>}
+          {errors.root?.serverError?.message && (
+            <p className="text-sm text-destructive">
+              {errors.root.serverError.message}
+            </p>
+          )}
 
-          <Button type="submit" className="w-full" disabled={loading}>
-            {loading ? "処理中..." : isLogin ? "ログイン" : "アカウント作成"}
-          </Button>
+          <LoadingButton type="submit" className="w-full" loading={loading}>
+            {isLogin ? "ログイン" : "アカウント作成"}
+          </LoadingButton>
         </form>
 
         <p className="text-center text-sm text-muted-foreground">

--- a/apps/web/src/views/auth/ui/use-auth-form-submit.ts
+++ b/apps/web/src/views/auth/ui/use-auth-form-submit.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useCallback } from "react";
+import type { UseFormSetError } from "react-hook-form";
+import { createSupabaseBrowserClient } from "@/shared/lib/supabase/client";
+import type { AuthFormValues } from "./auth-form-schema";
+
+interface UseAuthFormSubmitParams {
+  isLogin: boolean;
+  onSuccess: () => void;
+  setError: UseFormSetError<AuthFormValues>;
+}
+
+export function useAuthFormSubmit({
+  isLogin,
+  onSuccess,
+  setError,
+}: UseAuthFormSubmitParams) {
+  return useCallback(
+    async (values: AuthFormValues) => {
+      const supabase = createSupabaseBrowserClient();
+
+      const { error } = isLogin
+        ? await supabase.auth.signInWithPassword(values)
+        : await supabase.auth.signUp(values);
+
+      if (error) {
+        setError("root.serverError", {
+          type: "server",
+          message: error.message,
+        });
+        return;
+      }
+
+      onSuccess();
+    },
+    [isLogin, onSuccess, setError],
+  );
+}

--- a/apps/web/src/views/settings/ui/__tests__/category-form.test.tsx
+++ b/apps/web/src/views/settings/ui/__tests__/category-form.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { API_ERROR_CODES } from "@todo-list/schema";
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/shared/lib/api/errors";
+import type { Category } from "@/shared/types/task";
+import { CategoryForm } from "../category-form";
+
+const baseCategory: Category = {
+  id: "category-1",
+  name: "開発",
+  color: "#3B82F6",
+};
+
+function renderCategoryForm(
+  props: Partial<ComponentProps<typeof CategoryForm>> = {},
+) {
+  const addCategory =
+    props.addCategory ?? vi.fn().mockResolvedValue("created-category-id");
+  const updateCategory =
+    props.updateCategory ?? vi.fn().mockResolvedValue(undefined);
+  const onSuccess = props.onSuccess ?? vi.fn();
+  const onCancel = props.onCancel ?? vi.fn();
+
+  render(
+    <CategoryForm
+      editingCategory={null}
+      addCategory={addCategory}
+      updateCategory={updateCategory}
+      onSuccess={onSuccess}
+      onCancel={onCancel}
+      {...props}
+    />,
+  );
+
+  return {
+    addCategory,
+    onCancel,
+    onSuccess,
+    updateCategory,
+  };
+}
+
+describe("CategoryForm", () => {
+  it("空のカテゴリ名では送信せずエラーメッセージを表示する", async () => {
+    const user = userEvent.setup();
+    const { addCategory, onSuccess } = renderCategoryForm();
+
+    await user.click(screen.getByRole("button", { name: "追加" }));
+
+    expect(
+      await screen.findByText("カテゴリ名を入力してください"),
+    ).toBeVisible();
+    expect(addCategory).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("追加成功時にカテゴリ名をトリムして保存する", async () => {
+    const user = userEvent.setup();
+    const { addCategory, onSuccess } = renderCategoryForm();
+
+    await user.type(screen.getByLabelText("カテゴリ名 *"), "  会議  ");
+    await user.click(screen.getByRole("button", { name: "追加" }));
+
+    await waitFor(() =>
+      expect(addCategory).toHaveBeenCalledWith("会議", "#3B82F6"),
+    );
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it("API の field error をフォームに表示し、成功扱いにしない", async () => {
+    const user = userEvent.setup();
+    const { addCategory, onSuccess } = renderCategoryForm({
+      addCategory: vi.fn().mockRejectedValue(
+        new ApiError("Failed to create category", 400, {
+          code: API_ERROR_CODES.VALIDATION_ERROR,
+          message: "入力内容に誤りがあります",
+          errors: [
+            { field: "name", message: "同名のカテゴリは作成できません" },
+          ],
+        }),
+      ),
+    });
+
+    await user.type(screen.getByLabelText("カテゴリ名 *"), "開発");
+    await user.click(screen.getByRole("button", { name: "追加" }));
+
+    expect(
+      await screen.findByText("同名のカテゴリは作成できません"),
+    ).toBeVisible();
+    expect(addCategory).toHaveBeenCalledWith("開発", "#3B82F6");
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("編集モードでは updateCategory を呼ぶ", async () => {
+    const user = userEvent.setup();
+    const { updateCategory, onSuccess } = renderCategoryForm({
+      editingCategory: baseCategory,
+    });
+
+    const input = screen.getByLabelText("カテゴリ名 *");
+    await user.clear(input);
+    await user.type(input, "レビュー");
+    await user.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() =>
+      expect(updateCategory).toHaveBeenCalledWith(
+        baseCategory.id,
+        "レビュー",
+        baseCategory.color,
+      ),
+    );
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/views/settings/ui/category-form-schema.ts
+++ b/apps/web/src/views/settings/ui/category-form-schema.ts
@@ -1,0 +1,16 @@
+import { categoryColorSchema, categoryNameSchema } from "@todo-list/schema";
+import { z } from "zod";
+import { CATEGORY_COLORS } from "@/shared/constants/category-colors";
+
+export const categoryFormSchema = z.object({
+  name: z.string().trim().pipe(categoryNameSchema),
+  // UI では候補色に限定しつつ、共有 schema の HEX 制約も維持する
+  color: z
+    .string()
+    .refine((value) => CATEGORY_COLORS.includes(value), {
+      message: "カラーを選択してください",
+    })
+    .pipe(categoryColorSchema),
+});
+
+export type CategoryFormValues = z.infer<typeof categoryFormSchema>;

--- a/apps/web/src/views/settings/ui/category-form.tsx
+++ b/apps/web/src/views/settings/ui/category-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useController, useForm } from "react-hook-form";
 
 import { CATEGORY_COLORS } from "@/shared/constants/category-colors";
 import { cn } from "@/shared/lib/utils";
@@ -8,40 +9,66 @@ import type { Category } from "@/shared/types/task";
 import { LoadingButton } from "@/shared/ui/loading-button";
 import { Button } from "@/shared/ui/shadcn/button";
 import { Input } from "@/shared/ui/shadcn/input";
+import {
+  type CategoryFormValues,
+  categoryFormSchema,
+} from "./category-form-schema";
+import { useCategoryFormSubmit } from "./use-category-form-submit";
 
 interface CategoryFormProps {
   editingCategory: Category | null;
-  onSubmit: (name: string, color: string) => Promise<void>;
+  addCategory: (name: string, color: string) => Promise<string>;
+  updateCategory: (id: string, name: string, color: string) => Promise<void>;
+  onSuccess: () => void;
   onCancel: () => void;
   loading?: boolean;
 }
 
 export function CategoryForm({
   editingCategory,
-  onSubmit,
+  addCategory,
+  updateCategory,
+  onSuccess,
   onCancel,
   loading = false,
 }: CategoryFormProps) {
-  const [name, setName] = useState(editingCategory?.name ?? "");
-  const [color, setColor] = useState(
-    editingCategory?.color ?? CATEGORY_COLORS[0],
-  );
+  const {
+    control,
+    formState: { errors },
+    handleSubmit,
+    register,
+    setError,
+  } = useForm<CategoryFormValues>({
+    resolver: zodResolver(categoryFormSchema),
+    defaultValues: {
+      name: editingCategory?.name ?? "",
+      color: editingCategory?.color ?? CATEGORY_COLORS[0],
+    },
+  });
+  const { field: colorField } = useController({
+    control,
+    name: "color",
+  });
+  const submitCategoryForm = useCategoryFormSubmit({
+    editingCategory,
+    addCategory,
+    updateCategory,
+    onSuccess,
+    setError,
+  });
 
   const isEditing = editingCategory !== null;
   const title = isEditing ? "カテゴリ編集" : "カテゴリ追加";
   const submitLabel = isEditing ? "保存" : "追加";
-
-  const handleSubmit = async (e: React.SubmitEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const onSubmit = handleSubmit(async (values) => {
     if (loading) return;
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    await onSubmit(trimmed, color);
-  };
+    await submitCategoryForm(values);
+  });
 
   return (
     <form
-      onSubmit={handleSubmit}
+      onSubmit={onSubmit}
+      noValidate
       className="flex flex-col gap-6 rounded-3xl bg-card p-6"
     >
       <h3 className="text-base font-bold">{title}</h3>
@@ -54,9 +81,13 @@ export function CategoryForm({
           id="category-name"
           className="h-11 rounded-xl bg-background"
           placeholder="カテゴリ名を入力"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          aria-invalid={!!errors.name}
+          disabled={loading}
+          {...register("name")}
         />
+        {errors.name?.message && (
+          <p className="text-xs text-destructive">{errors.name.message}</p>
+        )}
       </div>
 
       <div className="flex flex-col gap-2">
@@ -66,19 +97,35 @@ export function CategoryForm({
             <button
               key={c}
               type="button"
-              onClick={() => setColor(c)}
+              aria-pressed={colorField.value === c}
+              disabled={loading}
+              onClick={() => colorField.onChange(c)}
               className={cn(
                 "size-8 rounded-full transition-all duration-200 ease-out",
-                color === c && "ring-2 ring-primary ring-offset-2",
+                colorField.value === c && "ring-2 ring-primary ring-offset-2",
               )}
               style={{ backgroundColor: c }}
             />
           ))}
         </div>
+        {errors.color?.message && (
+          <p className="text-xs text-destructive">{errors.color.message}</p>
+        )}
       </div>
 
+      {errors.root?.serverError?.message && (
+        <p className="text-sm text-destructive">
+          {errors.root.serverError.message}
+        </p>
+      )}
+
       <div className="flex items-center gap-3">
-        <Button type="button" variant="outline" onClick={onCancel}>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onCancel}
+          disabled={loading}
+        >
           キャンセル
         </Button>
         <LoadingButton type="submit" loading={loading}>

--- a/apps/web/src/views/settings/ui/settings-page.tsx
+++ b/apps/web/src/views/settings/ui/settings-page.tsx
@@ -91,18 +91,6 @@ export function SettingsPage({
     setFormState({ mode: "closed" });
   }, [deleteTarget, deleteCategory]);
 
-  const handleFormSubmit = useCallback(
-    async (name: string, color: string) => {
-      if (formState.mode === "add") {
-        await addCategory(name, color);
-      } else if (formState.mode === "edit") {
-        await updateCategory(formState.category.id, name, color);
-      }
-      setFormState({ mode: "closed" });
-    },
-    [formState, addCategory, updateCategory],
-  );
-
   const handleFormCancel = useCallback(() => {
     setFormState({ mode: "closed" });
   }, []);
@@ -146,7 +134,9 @@ export function SettingsPage({
                     formState.mode === "edit" ? formState.category.id : "add"
                   }
                   editingCategory={editingCategory}
-                  onSubmit={handleFormSubmit}
+                  addCategory={addCategory}
+                  updateCategory={updateCategory}
+                  onSuccess={handleFormCancel}
                   onCancel={handleFormCancel}
                   loading={
                     formState.mode === "edit"
@@ -177,7 +167,9 @@ export function SettingsPage({
                       : "mobile-add"
                   }
                   editingCategory={editingCategory}
-                  onSubmit={handleFormSubmit}
+                  addCategory={addCategory}
+                  updateCategory={updateCategory}
+                  onSuccess={handleFormCancel}
                   onCancel={handleFormCancel}
                   loading={
                     formState.mode === "edit"

--- a/apps/web/src/views/settings/ui/use-category-form-submit.ts
+++ b/apps/web/src/views/settings/ui/use-category-form-submit.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useCallback } from "react";
+import type { UseFormSetError } from "react-hook-form";
+import { ApiError } from "@/shared/lib/api/errors";
+import { applyApiFieldErrors } from "@/shared/lib/forms/apply-api-field-errors";
+import type { Category } from "@/shared/types/task";
+import type { CategoryFormValues } from "./category-form-schema";
+
+interface UseCategoryFormSubmitParams {
+  editingCategory: Category | null;
+  addCategory: (name: string, color: string) => Promise<string>;
+  updateCategory: (id: string, name: string, color: string) => Promise<void>;
+  onSuccess: () => void;
+  setError: UseFormSetError<CategoryFormValues>;
+}
+
+export function useCategoryFormSubmit({
+  editingCategory,
+  addCategory,
+  updateCategory,
+  onSuccess,
+  setError,
+}: UseCategoryFormSubmitParams) {
+  return useCallback(
+    async (values: CategoryFormValues) => {
+      try {
+        if (editingCategory) {
+          await updateCategory(editingCategory.id, values.name, values.color);
+        } else {
+          await addCategory(values.name, values.color);
+        }
+
+        onSuccess();
+      } catch (error) {
+        if (error instanceof ApiError) {
+          const handled = applyApiFieldErrors(error.fieldErrors, setError, {
+            name: "name",
+            color: "color",
+          });
+
+          if (!handled) {
+            setError("root.serverError", {
+              type: "server",
+              message: error.errorMessage,
+            });
+          }
+          return;
+        }
+
+        throw error;
+      }
+    },
+    [addCategory, editingCategory, onSuccess, setError, updateCategory],
+  );
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,6 +7,10 @@ pre-commit:
           echo "mainブランチでのcommitは禁止です。featureブランチを作成してください。" >&2
           exit 1
         fi
+    web-conventions:
+      run: pnpm lint
+      skip:
+        - run: "! git diff --cached --name-only | grep -qE '^(apps/web/src/|\\.agent-rules/web/|scripts/check-web-conventions\\.mjs|lefthook\\.yml|package\\.json)'"
     test:
       run: pnpm test
       skip:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "dev": "pnpm -r --parallel dev",
     "build": "pnpm -r build",
-    "lint": "pnpm -r lint",
+    "lint": "pnpm -r lint && pnpm check:web-conventions",
+    "check:web-conventions": "node scripts/check-web-conventions.mjs",
     "test": "pnpm -r test",
     "supabase:start": "pnpm exec supabase start",
     "supabase:stop": "pnpm exec supabase stop",

--- a/packages/schema/.oxlintrc.json
+++ b/packages/schema/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "unicorn", "oxc", "import"],
+  "categories": {
+    "correctness": "error"
+  },
+  "rules": {
+    "typescript/no-deprecated": "error"
+  }
+}

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -5,7 +5,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "lint": "oxlint --type-aware --type-check --deny typescript/no-deprecated src/"
+    "lint": "oxlint --type-aware --type-check src/"
   },
   "dependencies": {
     "zod": "^4.3.6"

--- a/packages/schema/src/category.ts
+++ b/packages/schema/src/category.ts
@@ -1,27 +1,20 @@
 import { z } from "zod";
-
-const hexColorSchema = z
-  .string()
-  .min(1, "カラーは必須です")
-  .regex(
-    /^#[0-9A-Fa-f]{6}$/,
-    "HEXカラーコード形式（例: #FF0000）で入力してください",
-  );
+import { categoryColorSchema, categoryNameSchema } from "./primitives";
 
 export const createCategorySchema = z.object({
-  name: z.string().min(1),
-  color: hexColorSchema,
+  name: categoryNameSchema,
+  color: categoryColorSchema,
 });
 
 export const updateCategorySchema = z.object({
-  name: z.string().min(1),
-  color: hexColorSchema,
+  name: categoryNameSchema,
+  color: categoryColorSchema,
 });
 
 export const categoryResponseSchema = z.object({
   id: z.uuid(),
   name: z.string(),
-  color: hexColorSchema,
+  color: categoryColorSchema,
 });
 
 export type CreateCategoryInput = z.infer<typeof createCategorySchema>;

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -14,6 +14,12 @@ export {
 } from "./category";
 export { type IdParam, idParamSchema } from "./common";
 export {
+  categoryColorSchema,
+  categoryNameSchema,
+  estimatedMinutesSchema,
+  taskNameSchema,
+} from "./primitives";
+export {
   type CreateTaskInput,
   createTaskSchema,
   type TaskResponse,

--- a/packages/schema/src/primitives.ts
+++ b/packages/schema/src/primitives.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const taskNameSchema = z
+  .string()
+  .min(1, "タスク名を入力してください")
+  .max(100, "タスク名は100文字以内で入力してください");
+
+export const categoryNameSchema = z
+  .string()
+  .min(1, "カテゴリ名を入力してください")
+  .max(50, "カテゴリ名は50文字以内で入力してください");
+
+export const categoryColorSchema = z
+  .string()
+  .min(1, "カラーは必須です")
+  .regex(
+    /^#[0-9A-Fa-f]{6}$/,
+    "HEXカラーコード形式（例: #FF0000）で入力してください",
+  );
+
+export const estimatedMinutesSchema = z
+  .number("見積もり時間を正しく選択してください")
+  .int("見積もり時間を正しく選択してください")
+  .positive("見積もり時間を正しく選択してください")
+  .nullable();

--- a/packages/schema/src/task.ts
+++ b/packages/schema/src/task.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { estimatedMinutesSchema, taskNameSchema } from "./primitives";
 
 const taskStatusEnum = z.enum(["todo", "in_progress", "done"]);
 const nullableUuidSchema = z.preprocess(
@@ -7,18 +8,18 @@ const nullableUuidSchema = z.preprocess(
 );
 
 export const createTaskSchema = z.object({
-  name: z.string().min(1),
+  name: taskNameSchema,
   categoryId: nullableUuidSchema,
-  estimatedMinutes: z.number().int().positive().nullable(),
+  estimatedMinutes: estimatedMinutesSchema,
   scheduledDate: z.iso.date().nullable(),
 });
 
 export const updateTaskSchema = z.object({
-  name: z.string().min(1),
+  name: taskNameSchema,
   categoryId: nullableUuidSchema,
   status: taskStatusEnum,
   isNext: z.boolean(),
-  estimatedMinutes: z.number().int().positive().nullable(),
+  estimatedMinutes: estimatedMinutesSchema,
   scheduledDate: z.iso.date().nullable(),
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.73.1(react@19.2.5))
       '@supabase/ssr':
         specifier: ^0.10.2
         version: 0.10.2(@supabase/supabase-js@2.103.3)
@@ -123,12 +126,18 @@ importers:
       react-dom:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
+      react-hook-form:
+        specifier: ^7.73.1
+        version: 7.73.1(react@19.2.5)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.2.2
@@ -386,28 +395,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.12':
     resolution: {integrity: sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.12':
     resolution: {integrity: sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.12':
     resolution: {integrity: sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.12':
     resolution: {integrity: sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==}
@@ -689,6 +694,11 @@ packages:
       hono: '>=3.9.0'
       zod: ^3.25.0 || ^4.0.0
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -719,105 +729,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -934,28 +928,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.4':
     resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.4':
     resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.4':
     resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.4':
     resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
@@ -1082,56 +1072,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.60.0':
     resolution: {integrity: sha512-eDYDXZGhQAXyn6GwtwiX/qcLS0HlOLPJ/+iiIY8RYr+3P8oKBmgKxADLlniL6FtWfE7pPk7IGN9/xvDEvDvFeg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.60.0':
     resolution: {integrity: sha512-nxehly5XYBHUWI9VJX1bqCf9j/B43DaK/aS/T1fcxCpX3PA4Rm9BB54nPD1CKayT8xg6REN1ao+01hSRNgy8OA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.60.0':
     resolution: {integrity: sha512-j1qf/NaUfOWQutjeoooNG1Q0zsK0XGmSu1uDLq3cctquRF3j7t9Hxqf/76ehCc5GEUAanth2W4Fa+XT1RFg/nw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.60.0':
     resolution: {integrity: sha512-YELKPRefQ/q/h3RUmeRfPCUhh2wBvgV1RyZ/F9M9u8cDyXsQW2ojv1DeWQTt466yczDITjZnIOg/s05pk7Ve2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.60.0':
     resolution: {integrity: sha512-JkO3C6Gki7Y6h/MiIkFKvHFOz98/YWvQ4WYbK9DLXACMP2rjULzkeGyAzorJE5S1dzLQGFgeqvN779kSFwoV1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.60.0':
     resolution: {integrity: sha512-XjKHdFVCpZZZSWBCKyyqCq65s2AKXykMXkjLoKYODrD+f5toLhlwsMESscu8FbgnJQ4Y/dpR/zdazsahmgBJIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.60.0':
     resolution: {integrity: sha512-js29ZWIuPhNWzY8NC7KoffEMEeWG105vbmm+8EOJsC+T/jHBiKIJEUF78+F/IrgEWMMP9N0kRND4Pp75+xAhKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.60.0':
     resolution: {integrity: sha512-H+PUITKHk04stFpWj3x3Kg08Afp/bcXSBi0EhasR5a0Vw7StXHTzdl655PUI0fB4qdh2Wsu6Dsi+3ACxPoyQnA==}
@@ -1950,79 +1932,66 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -2063,6 +2032,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@supabase/auth-js@2.103.3':
     resolution: {integrity: sha512-SMDJ4vg5jLXNEHdhN4J4ujSb203WangbDw1n3VaARH0ZqM51E6lJnoUAHlpQU9N7SzP0hfgghA9IvT8c7tGRfg==}
@@ -2141,28 +2113,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -3288,28 +3256,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3811,6 +3775,12 @@ packages:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
+
+  react-hook-form@7.73.1:
+    resolution: {integrity: sha512-VAfVYOPcx3piiEVQy95vyFmBwbVUsP/AUIN+mpFG8h11yshDd444nn0VyfaGWSRnhOLVgiDu7HIuBtAIzxn9dA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -4909,6 +4879,11 @@ snapshots:
     dependencies:
       hono: 4.12.14
       zod: 4.3.6
+
+  '@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.5))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.73.1(react@19.2.5)
 
   '@img/colour@1.1.0':
     optional: true
@@ -6152,6 +6127,8 @@ snapshots:
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@supabase/auth-js@2.103.3':
     dependencies:
@@ -7896,6 +7873,10 @@ snapshots:
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react-hook-form@7.73.1(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   react-is@17.0.2: {}
 

--- a/scripts/check-web-conventions.mjs
+++ b/scripts/check-web-conventions.mjs
@@ -1,0 +1,108 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const rootDir = process.cwd();
+const webSrcDir = path.join(rootDir, "apps/web/src");
+
+function walk(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...walk(fullPath));
+      continue;
+    }
+
+    files.push(fullPath);
+  }
+
+  return files;
+}
+
+function toRepoPath(filePath) {
+  return path.relative(rootDir, filePath).replaceAll(path.sep, "/");
+}
+
+function isTestFile(repoPath) {
+  return /\.test\.(ts|tsx)$/.test(repoPath);
+}
+
+function isInTestsDir(repoPath) {
+  return repoPath.includes("/__tests__/");
+}
+
+function isFormComponent(repoPath) {
+  if (!repoPath.endsWith("-form.tsx")) return false;
+  if (repoPath.includes("/__tests__/")) return false;
+  if (repoPath.includes("/shared/ui/shadcn/")) return false;
+  return (
+    repoPath.startsWith("apps/web/src/shared/ui/") ||
+    repoPath.includes("/views/") ||
+    repoPath.startsWith("apps/web/src/views/")
+  );
+}
+
+function checkTestPlacement(files, violations) {
+  for (const filePath of files) {
+    const repoPath = toRepoPath(filePath);
+
+    if (!isTestFile(repoPath)) continue;
+    if (isInTestsDir(repoPath)) continue;
+
+    violations.push(
+      `テストファイルは __tests__/ 配下に置いてください: ${repoPath}`,
+    );
+  }
+}
+
+function checkFormFileConventions(files, violations) {
+  for (const filePath of files) {
+    const repoPath = toRepoPath(filePath);
+    if (!isFormComponent(repoPath)) continue;
+
+    const dir = path.dirname(filePath);
+    const stem = path.basename(filePath, ".tsx");
+    const schemaPath = path.join(dir, `${stem}-schema.ts`);
+    const submitHookPath = path.join(dir, `use-${stem}-submit.ts`);
+
+    if (!existsSync(schemaPath)) {
+      violations.push(
+        `フォームコンポーネントには同ディレクトリの schema が必要です: ${repoPath} -> ${toRepoPath(schemaPath)}`,
+      );
+    }
+
+    if (!existsSync(submitHookPath)) {
+      violations.push(
+        `フォームコンポーネントには同ディレクトリの submit hook が必要です: ${repoPath} -> ${toRepoPath(submitHookPath)}`,
+      );
+    }
+  }
+}
+
+function main() {
+  if (!statSync(webSrcDir).isDirectory()) {
+    throw new Error(`apps/web/src が見つかりません: ${webSrcDir}`);
+  }
+
+  const files = walk(webSrcDir);
+  const violations = [];
+
+  checkTestPlacement(files, violations);
+  checkFormFileConventions(files, violations);
+
+  if (violations.length === 0) {
+    console.log("web conventions: ok");
+    return;
+  }
+
+  console.error("web conventions: failed");
+  for (const violation of violations) {
+    console.error(`- ${violation}`);
+  }
+  process.exitCode = 1;
+}
+
+main();


### PR DESCRIPTION
## 概要

フォームバリデーション実装を `react-hook-form + zod` ベースに揃えつつ、共有 schema・テスト配置・lint/convention check を含むハーネスを整備した。

closes #60

## 変更内容

- カテゴリ / タスク / 認証フォームを `react-hook-form + zodResolver` ベースに変更
- API field error を `setError` に流す共通処理と submit hook を追加
- `packages/schema` に共通 primitive schema を追加し、web の form schema から再利用する構成に変更
- フォーム UI テストを追加し、`__tests__/` 配下へ統一
- `typescript/no-deprecated` を `web` / `api` / `schema` に揃えて有効化
- `pnpm lint` で `oxlint` と `check:web-conventions` をまとめて実行する構成に整理
- Web ルールを軽量化しつつ、フォームバリデーション方針を追加
- Google Fonts 依存を外し、日本語向け system font stack に変更

## 確認方法

- [x] `pnpm build` が通る
- [x] `pnpm lint` が通る
- [ ] ブラウザで動作確認済み
