### PR TITLE
fix: ログインエラーメッセージを日本語化

### DIFF
--- a/apps/web/src/views/auth/ui/__tests__/auth-form.test.tsx
+++ b/apps/web/src/views/auth/ui/__tests__/auth-form.test.tsx
@@ -98,4 +98,29 @@ describe("AuthForm", () => {
 
     expect(await screen.findByText("Email rate limit exceeded")).toBeVisible();
   });
+
+  it("invalid_credentials エラーを日本語で表示する", async () => {
+    const user = userEvent.setup();
+    signInWithPassword.mockResolvedValue({
+      error: {
+        code: "invalid_credentials",
+        message: "Invalid login credentials",
+      },
+    });
+
+    render(<AuthForm mode="login" />);
+
+    await user.type(
+      screen.getByLabelText("メールアドレス"),
+      "mail@example.com",
+    );
+    await user.type(screen.getByLabelText("パスワード"), "wrong-password");
+    await user.click(screen.getByRole("button", { name: "ログイン" }));
+
+    expect(
+      await screen.findByText(
+        "メールアドレスまたはパスワードが正しくありません",
+      ),
+    ).toBeVisible();
+  });
 });

--- a/apps/web/src/views/auth/ui/use-auth-form-submit.ts
+++ b/apps/web/src/views/auth/ui/use-auth-form-submit.ts
@@ -5,6 +5,17 @@ import type { UseFormSetError } from "react-hook-form";
 import { createSupabaseBrowserClient } from "@/shared/lib/supabase/client";
 import type { AuthFormValues } from "./auth-form-schema";
 
+/** Supabase Auth のエラーコードを日本語メッセージに変換する */
+function toJapaneseMessage(code: string | undefined, fallback: string): string {
+  switch (code) {
+    case "invalid_credentials":
+      return "メールアドレスまたはパスワードが正しくありません";
+    case undefined:
+    default:
+      return fallback;
+  }
+}
+
 interface UseAuthFormSubmitParams {
   isLogin: boolean;
   onSuccess: () => void;
@@ -27,7 +38,7 @@ export function useAuthFormSubmit({
       if (error) {
         setError("root.serverError", {
           type: "server",
-          message: error.message,
+          message: toJapaneseMessage(error.code, error.message),
         });
         return;
       }


### PR DESCRIPTION
## 概要

Supabase Auth のログインエラーメッセージを日本語で表示するようにした。

## 変更内容

- `error.code` ベースでエラーメッセージを日本語に変換する `toJapaneseMessage` 関数を追加
- `invalid_credentials` の場合「メールアドレスまたはパスワードが正しくありません」と表示
- 未知のエラーコードはSupabaseのメッセージをそのまま表示（フォールバック）
- テストを追加

## 確認方法

- [x] `pnpm build` が通る
- [x] `pnpm lint` が通る
- [ ] ブラウザで動作確認済み
