### PR TITLE
refactor: DB命名をPostgreSQL慣習のsnake_caseに統一

### DIFF
--- a/apps/api/prisma/migrations/20260427000000_rename_to_snake_case/migration.sql
+++ b/apps/api/prisma/migrations/20260427000000_rename_to_snake_case/migration.sql
@@ -1,0 +1,35 @@
+-- RenameEnum
+ALTER TYPE "TaskStatus" RENAME TO "task_status";
+ALTER TYPE "WorkResult" RENAME TO "work_result";
+
+-- RenameTables
+ALTER TABLE "Category" RENAME TO "categories";
+ALTER TABLE "Task" RENAME TO "tasks";
+ALTER TABLE "WorkRecord" RENAME TO "work_records";
+ALTER TABLE "TimerSession" RENAME TO "timer_sessions";
+
+-- RenameColumns: categories
+ALTER TABLE "categories" RENAME COLUMN "userId" TO "user_id";
+
+-- RenameColumns: tasks
+ALTER TABLE "tasks" RENAME COLUMN "userId" TO "user_id";
+ALTER TABLE "tasks" RENAME COLUMN "categoryId" TO "category_id";
+ALTER TABLE "tasks" RENAME COLUMN "isNext" TO "is_next";
+ALTER TABLE "tasks" RENAME COLUMN "estimatedMinutes" TO "estimated_minutes";
+ALTER TABLE "tasks" RENAME COLUMN "scheduledDate" TO "scheduled_date";
+ALTER TABLE "tasks" RENAME COLUMN "createdAt" TO "created_at";
+ALTER TABLE "tasks" RENAME COLUMN "updatedAt" TO "updated_at";
+
+-- RenameColumns: work_records
+ALTER TABLE "work_records" RENAME COLUMN "userId" TO "user_id";
+ALTER TABLE "work_records" RENAME COLUMN "taskId" TO "task_id";
+ALTER TABLE "work_records" RENAME COLUMN "durationMinutes" TO "duration_minutes";
+
+-- RenameColumns: timer_sessions
+ALTER TABLE "timer_sessions" RENAME COLUMN "userId" TO "user_id";
+ALTER TABLE "timer_sessions" RENAME COLUMN "singletonKey" TO "singleton_key";
+ALTER TABLE "timer_sessions" RENAME COLUMN "taskId" TO "task_id";
+ALTER TABLE "timer_sessions" RENAME COLUMN "taskName" TO "task_name";
+ALTER TABLE "timer_sessions" RENAME COLUMN "categoryName" TO "category_name";
+ALTER TABLE "timer_sessions" RENAME COLUMN "estimatedMinutes" TO "estimated_minutes";
+ALTER TABLE "timer_sessions" RENAME COLUMN "startedAt" TO "started_at";

--- a/apps/api/prisma/migrations/20260427000001_fix_constraints/migration.sql
+++ b/apps/api/prisma/migrations/20260427000001_fix_constraints/migration.sql
@@ -1,0 +1,29 @@
+-- AlterTable
+ALTER TABLE "categories" RENAME CONSTRAINT "Category_pkey" TO "categories_pkey";
+
+-- AlterTable
+ALTER TABLE "tasks" RENAME CONSTRAINT "Task_pkey" TO "tasks_pkey";
+
+-- AlterTable
+ALTER TABLE "timer_sessions" RENAME CONSTRAINT "TimerSession_pkey" TO "timer_sessions_pkey";
+
+-- AlterTable
+ALTER TABLE "work_records" RENAME CONSTRAINT "WorkRecord_pkey" TO "work_records_pkey";
+
+-- RenameForeignKey
+ALTER TABLE "tasks" RENAME CONSTRAINT "Task_categoryId_userId_fkey" TO "tasks_category_id_user_id_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "timer_sessions" RENAME CONSTRAINT "TimerSession_taskId_userId_fkey" TO "timer_sessions_task_id_user_id_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "work_records" RENAME CONSTRAINT "WorkRecord_taskId_userId_fkey" TO "work_records_task_id_user_id_fkey";
+
+-- RenameIndex
+ALTER INDEX "Category_id_userId_key" RENAME TO "categories_id_user_id_key";
+
+-- RenameIndex
+ALTER INDEX "Task_id_userId_key" RENAME TO "tasks_id_user_id_key";
+
+-- RenameIndex
+ALTER INDEX "TimerSession_userId_singletonKey_key" RENAME TO "timer_sessions_user_id_singleton_key_key";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -10,61 +10,70 @@ enum TaskStatus {
   todo
   in_progress
   done
+
+  @@map("task_status")
 }
 
 enum WorkResult {
   completed
   interrupted
+
+  @@map("work_result")
 }
 
 model Category {
   id     String @id @default(uuid()) @db.Uuid
-  userId String
+  userId String @map("user_id")
   name   String
   color  String
   tasks  Task[]
 
   @@unique([id, userId])
+  @@map("categories")
 }
 
 model Task {
   id               String         @id @default(uuid()) @db.Uuid
-  userId           String
+  userId           String         @map("user_id")
   name             String
-  categoryId       String?        @db.Uuid
+  categoryId       String?        @map("category_id") @db.Uuid
   category         Category?      @relation(fields: [categoryId, userId], references: [id, userId], onDelete: Restrict)
   status           TaskStatus     @default(todo)
-  isNext           Boolean        @default(false)
-  estimatedMinutes Int?
-  scheduledDate    String?
-  createdAt        DateTime       @default(now())
-  updatedAt        DateTime       @updatedAt
+  isNext           Boolean        @default(false) @map("is_next")
+  estimatedMinutes Int?           @map("estimated_minutes")
+  scheduledDate    String?        @map("scheduled_date")
+  createdAt        DateTime       @default(now()) @map("created_at")
+  updatedAt        DateTime       @updatedAt @map("updated_at")
   workRecords      WorkRecord[]
   timerSessions    TimerSession[]
 
   @@unique([id, userId])
+  @@map("tasks")
 }
 
 model WorkRecord {
   id              String     @id @default(uuid()) @db.Uuid
-  userId          String
-  taskId          String     @db.Uuid
+  userId          String     @map("user_id")
+  taskId          String     @map("task_id") @db.Uuid
   task            Task       @relation(fields: [taskId, userId], references: [id, userId], onDelete: Cascade)
   date            String
-  durationMinutes Int
+  durationMinutes Int        @map("duration_minutes")
   result          WorkResult
+
+  @@map("work_records")
 }
 
 model TimerSession {
   id               String   @id @default(uuid()) @db.Uuid
-  userId           String
-  singletonKey     String   @default("active")
-  taskId           String   @db.Uuid
+  userId           String   @map("user_id")
+  singletonKey     String   @default("active") @map("singleton_key")
+  taskId           String   @map("task_id") @db.Uuid
   task             Task     @relation(fields: [taskId, userId], references: [id, userId], onDelete: Cascade)
-  taskName         String
-  categoryName     String
-  estimatedMinutes Int
-  startedAt        DateTime @default(now())
+  taskName         String   @map("task_name")
+  categoryName     String   @map("category_name")
+  estimatedMinutes Int      @map("estimated_minutes")
+  startedAt        DateTime @default(now()) @map("started_at")
 
   @@unique([userId, singletonKey])
+  @@map("timer_sessions")
 }


### PR DESCRIPTION
## 概要

DB上のテーブル名・カラム名をPostgreSQL慣習のsnake_caseに統一した。
psqlで `SELECT * FROM tasks;` のようにクォートなしでクエリできるようになる。

## 変更内容

- Prismaの `@@map` / `@map` でDB上の名前だけsnake_caseに変更
  - テーブル名: PascalCase → snake_case複数形（例: `Task` → `tasks`）
  - カラム名: camelCase → snake_case（例: `userId` → `user_id`）
  - enum名: PascalCase → snake_case（例: `TaskStatus` → `task_status`）
- Prismaクライアント側はcamelCaseのまま（APIコード変更なし）
- マイグレーションはDROP/CREATEではなくALTER TABLE RENAMEで既存データを保持

## 確認方法

- [x] `pnpm build` が通る
- [x] `pnpm test` が通る
- [ ] psqlで `SELECT * FROM tasks;` が動作する
