### PR TITLE
refactor: middleware file conventionをproxyに移行

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   let response = NextResponse.next({ request });
 
   const supabase = createServerClient(


### PR DESCRIPTION
## 概要

Next.js 16で非推奨となったmiddleware file conventionをproxy file conventionに移行する。

closes #62

## 変更内容

- `apps/web/src/middleware.ts` → `apps/web/src/proxy.ts` にリネーム
- エクスポート関数名を `middleware` → `proxy` に変更

## 確認方法

- [x] `pnpm build` が通る
- [x] `pnpm lint` が通る
- [ ] ブラウザで動作確認済み
- [x] ビルド時に `middleware file convention is deprecated` の警告が出ない
