### PR TITLE
refactor: useTimerの不要なuseEffectを削減

### DIFF
--- a/apps/web/src/shared/hooks/__tests__/use-timer.test.ts
+++ b/apps/web/src/shared/hooks/__tests__/use-timer.test.ts
@@ -195,4 +195,22 @@ describe("useTimer", () => {
     expect(result.current.isRunning).toBe(true);
     expect(result.current.remainingSeconds).toBe(15 * 60);
   });
+
+  it("セッションなしでestimatedMinutesが変わるとremainingSecondsが更新される", () => {
+    vi.mocked(api.fetchCurrentTimerSession).mockResolvedValue(null);
+    const { wrapper } = createQueryClientWrapper();
+
+    let minutes = 25;
+    const { result, rerender } = renderHook(
+      () => useTimer({ ...DEFAULT_INPUT, estimatedMinutes: minutes }, null),
+      { wrapper },
+    );
+
+    expect(result.current.remainingSeconds).toBe(25 * 60);
+
+    minutes = 50;
+    rerender();
+
+    expect(result.current.remainingSeconds).toBe(50 * 60);
+  });
 });

--- a/apps/web/src/shared/hooks/use-timer.ts
+++ b/apps/web/src/shared/hooks/use-timer.ts
@@ -39,7 +39,7 @@ function calcRemainingSeconds(
   return Math.max(0, remaining);
 }
 
-function getInitialState(
+function calcInitialState(
   session: TimerSession | null,
   estimatedMinutes: number,
 ) {
@@ -65,7 +65,7 @@ export function useTimer(
 ): UseTimerReturn {
   const { session, createSession, clearSession } =
     useCurrentTimerSession(initialSession);
-  const initialState = getInitialState(session, input.estimatedMinutes);
+  const initialState = calcInitialState(session, input.estimatedMinutes);
 
   const [remainingSeconds, setRemainingSeconds] = useState(
     initialState.remainingSeconds,
@@ -82,13 +82,17 @@ export function useTimer(
     }
   }, []);
 
-  useEffect(() => {
-    const nextState = getInitialState(session, input.estimatedMinutes);
+  // session 変更時に状態をリセット（レンダリング中の状態更新パターン）
+  const [prevSession, setPrevSession] = useState(session);
+  if (session !== prevSession) {
+    setPrevSession(session);
+    const nextState = calcInitialState(session, input.estimatedMinutes);
     setRemainingSeconds(nextState.remainingSeconds);
     setIsRunning(nextState.isRunning);
     setIsFinished(nextState.isFinished);
-  }, [input.estimatedMinutes, session]);
+  }
 
+  // 外部システム同期: タイマーの setInterval 管理
   useEffect(() => {
     if (!isRunning || isFinished || !session) return;
 

--- a/apps/web/src/shared/hooks/use-timer.ts
+++ b/apps/web/src/shared/hooks/use-timer.ts
@@ -82,10 +82,12 @@ export function useTimer(
     }
   }, []);
 
-  // session 変更時に状態をリセット（レンダリング中の状態更新パターン）
+  // session / estimatedMinutes 変更時に状態をリセット（レンダリング中の状態更新パターン）
   const [prevSession, setPrevSession] = useState(session);
-  if (session !== prevSession) {
+  const [prevMinutes, setPrevMinutes] = useState(input.estimatedMinutes);
+  if (session !== prevSession || input.estimatedMinutes !== prevMinutes) {
     setPrevSession(session);
+    setPrevMinutes(input.estimatedMinutes);
     const nextState = calcInitialState(session, input.estimatedMinutes);
     setRemainingSeconds(nextState.remainingSeconds);
     setIsRunning(nextState.isRunning);


### PR DESCRIPTION
## 概要

`useTimer` フックの状態同期 useEffect をレンダリング中の状態更新パターンに置き換え、不要な useEffect を削減する。

closes #21

## 変更内容

- `use-timer.ts` の状態同期 useEffect を React 推奨の「レンダリング中の状態更新」パターンに置換
- useEffect 2つ → 1つに削減（残りは setInterval 管理の正当な useEffect）
- `getInitialState` → `calcInitialState` にリネーム

### 対応しなかったもの（正当な useEffect）

- `use-timer.ts`: setInterval 管理（外部システム同期）
- `timer-page-content.tsx`: タイマー自動開始（マウント時の副作用、exhaustive-deps disable は既に解消済み）

## 確認方法

- [x] `pnpm build` が通る
- [x] `pnpm lint` が通る
- [x] `pnpm test` が通る
- [ ] ブラウザで動作確認済み
