### PR TITLE
Clarify package installation rule

### DIFF
--- a/.agent-rules/package-management.md
+++ b/.agent-rules/package-management.md
@@ -3,4 +3,8 @@ paths:
   - "**/package.json"
 ---
 
-パッケージの追加は `pnpm add <package>` コマンドを使うこと。package.json を直接編集して依存パッケージを追加しない。
+パッケージの追加は `pnpm add <package>` コマンドを使うこと。`package.json` を直接編集して依存パッケージを追加しない。
+
+monorepo では対象 workspace に対して追加すること。対象ディレクトリで `pnpm add` を実行するか、`pnpm --filter <workspace> add ...` を使う。
+
+新規追加時はバージョンを手で固定せず、`pnpm add` でその時点の互換のある版を解決する。互換性が重要な依存は `peerDependencies` も確認する。


### PR DESCRIPTION
## 概要

パッケージ追加ルールを補強し、monorepo での追加先と `pnpm add` を使う意図を明確化。

## 変更内容

- 対象 workspace に対して依存を追加することを明記
- 対象ディレクトリ実行または `pnpm --filter <workspace> add ...` の利用を明記
- バージョンは手で固定せず、`pnpm add` で互換のある版を解決することを明記
- 互換性が重要な依存では `peerDependencies` も確認することを追記

## 確認方法

- [x] `pnpm build` が通る
- [x] `pnpm lint` が通る
- [ ] ブラウザで動作確認済み
