### PR TITLE
セキュリティ対策: Cache-Control / 入力バリデーション / 攻撃者視点テスト

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,9 +12,7 @@
       "Write(**/tsconfig.json)",
       "Write(**/package.json)"
     ],
-    "allow": [
-      "Bash(ln -s:*)"
-    ],
+    "allow": ["Bash(ln -s:*)"],
     "deny": [
       "Edit(apps/web/src/shared/ui/shadcn/**)",
       "Write(apps/web/src/shared/ui/shadcn/**)",
@@ -23,7 +21,11 @@
       "Edit(apps/api/src/features/**/schema.ts)",
       "Write(apps/api/src/features/**/schema.ts)",
       "Edit(apps/api/src/features/**/handler.ts)",
-      "Write(apps/api/src/features/**/handler.ts)"
+      "Write(apps/api/src/features/**/handler.ts)",
+      "Bash(git commit --no-verify:*)",
+      "Bash(git commit*--no-verify*)",
+      "Bash(git push --no-verify:*)",
+      "Bash(git push*--no-verify*)"
     ]
   },
   "hooks": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,8 +24,10 @@
       "Write(apps/api/src/features/**/handler.ts)",
       "Bash(git commit --no-verify:*)",
       "Bash(git commit*--no-verify*)",
+      "Bash(git commit -n:*)",
       "Bash(git push --no-verify:*)",
-      "Bash(git push*--no-verify*)"
+      "Bash(git push*--no-verify*)",
+      "Bash(git push -n:*)"
     ]
   },
   "hooks": {

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,4 +1,3 @@
-approval_policy = "never"
 [features]
 codex_hooks = true
 

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -27,9 +27,81 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["git", "commit", "--no-verify"],
+    decision = "forbidden",
+    justification = "Do not bypass Git hooks with --no-verify.",
+    match = [
+        "git commit --no-verify -m 'chore: bypass hooks'",
+    ],
+    not_match = [
+        "git commit -m 'chore: update config'",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "commit", "--amend", "--no-edit", "--no-verify"],
+    decision = "forbidden",
+    justification = "Do not bypass Git hooks with --no-verify.",
+    match = [
+        "git commit --amend --no-edit --no-verify",
+    ],
+    not_match = [
+        "git commit --amend --no-edit",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "commit", "-n"],
+    decision = "forbidden",
+    justification = "Do not bypass Git hooks with -n.",
+    match = [
+        "git commit -n -m 'chore: bypass hooks'",
+    ],
+    not_match = [
+        "git commit -m 'chore: update config'",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "push", "--no-verify"],
+    decision = "forbidden",
+    justification = "Do not bypass Git hooks with --no-verify.",
+    match = [
+        "git push --no-verify origin HEAD",
+    ],
+    not_match = [
+        "git push origin HEAD",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "push", "--force-with-lease", "--no-verify"],
+    decision = "forbidden",
+    justification = "Do not bypass Git hooks with --no-verify.",
+    match = [
+        "git push --force-with-lease --no-verify origin HEAD",
+    ],
+    not_match = [
+        "git push --force-with-lease origin HEAD",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "push", "-n"],
+    decision = "forbidden",
+    justification = "Do not bypass Git hooks with -n.",
+    match = [
+        "git push -n origin HEAD",
+    ],
+    not_match = [
+        "git push origin HEAD",
+    ],
+)
+
+prefix_rule(
     pattern = ["git", "commit"],
-    decision = "allow",
-    justification = "Allow local commits without prompting.",
+    decision = "prompt",
+    justification = "Review Git commits explicitly; do not bypass hooks.",
     match = [
         "git commit -m 'chore: update config'",
         "git commit --amend --no-edit",
@@ -38,10 +110,21 @@ prefix_rule(
 
 prefix_rule(
     pattern = ["git", "push", "origin"],
-    decision = "allow",
-    justification = "Allow pushing the current branch to origin without prompting.",
+    decision = "prompt",
+    justification = "Review Git pushes explicitly; do not bypass hooks.",
     match = [
         "git push origin HEAD",
+        "git push origin main",
+        "git push origin feature/add-task-filter",
+    ],
+)
+
+prefix_rule(
+    pattern = ["git", "push", "--force-with-lease", "origin"],
+    decision = "prompt",
+    justification = "Review force-with-lease pushes explicitly; do not bypass hooks.",
+    match = [
+        "git push --force-with-lease origin HEAD",
     ],
 )
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ next-env.d.ts
 # Claude Code
 .claude/settings.local.json
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 .claude/skills/*
 !.claude/skills/browser-testing
 !.claude/skills/create-issue

--- a/apps/api/src/__tests__/attack-vectors.test.ts
+++ b/apps/api/src/__tests__/attack-vectors.test.ts
@@ -1,6 +1,7 @@
 import { jwtVerify } from "jose";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import app from "../app";
+import * as categoryService from "../features/categories/service";
 import { cleanDatabase, prisma } from "./helpers/db";
 
 // 攻撃者視点の横断テスト
@@ -14,6 +15,16 @@ vi.mock("jose", () => ({
     payload: { sub: "test-user-id" },
   }),
 }));
+
+// onError 経由の Cache-Control 検証用に list を spy 化（デフォルトは実装を呼ぶ）
+vi.mock("../features/categories/service", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../features/categories/service")>();
+  return {
+    ...actual,
+    list: vi.fn().mockImplementation(actual.list),
+  };
+});
 
 describe("セキュリティ - 攻撃シナリオ", () => {
   beforeEach(async () => {
@@ -101,6 +112,21 @@ describe("セキュリティ - 攻撃シナリオ", () => {
 
       const count = await prisma.category.count();
       expect(count).toBe(0);
+    });
+  });
+
+  describe("レスポンスヘッダ", () => {
+    it("500 (onError 経路) でも Cache-Control: no-store, private が付く", async () => {
+      vi.mocked(categoryService.list).mockRejectedValueOnce(
+        new Error("simulated unhandled error"),
+      );
+
+      const res = await app.request("/categories", {
+        headers: { Authorization: "Bearer test-token" },
+      });
+
+      expect(res.status).toBe(500);
+      expect(res.headers.get("Cache-Control")).toBe("no-store, private");
     });
   });
 

--- a/apps/api/src/__tests__/attack-vectors.test.ts
+++ b/apps/api/src/__tests__/attack-vectors.test.ts
@@ -1,0 +1,386 @@
+import { jwtVerify } from "jose";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../app";
+import { cleanDatabase, prisma } from "./helpers/db";
+
+// 攻撃者視点の横断テスト
+// 認証バイパス、IDOR、SQL インジェクション、境界値の挙動を検証する。
+// 各 feature の通常系・ユーザー隔離テストは `features/*/__tests__/` に存在する前提で、
+// ここでは追加でカバーすべき攻撃シナリオに絞って検証する。
+
+vi.mock("jose", () => ({
+  createRemoteJWKSet: vi.fn(),
+  jwtVerify: vi.fn().mockResolvedValue({
+    payload: { sub: "test-user-id" },
+  }),
+}));
+
+describe("セキュリティ - 攻撃シナリオ", () => {
+  beforeEach(async () => {
+    await cleanDatabase();
+    // 直前のテストの mockResolvedValueOnce / mockRejectedValueOnce が
+    // 残っていると次のテストへ漏れるため、mockReset してから再設定する
+    vi.mocked(jwtVerify).mockReset();
+    vi.mocked(jwtVerify).mockResolvedValue({
+      payload: { sub: "test-user-id" },
+    } as never);
+  });
+
+  afterAll(async () => {
+    await cleanDatabase();
+    await prisma.$disconnect();
+  });
+
+  describe("認証なしでのアクセス", () => {
+    it("Authorization ヘッダなしの GET /tasks は 401", async () => {
+      const res = await app.request("/tasks");
+      expect(res.status).toBe(401);
+    });
+
+    it("Authorization ヘッダなしの POST /categories は 401", async () => {
+      const res = await app.request("/categories", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Work", color: "#0000FF" }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("Authorization ヘッダなしの DELETE /tasks/:id は 401", async () => {
+      const res = await app.request(
+        "/tasks/00000000-0000-0000-0000-000000000000",
+        { method: "DELETE" },
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("Bearer 以外のスキーム（Basic）は 401", async () => {
+      const res = await app.request("/tasks", {
+        headers: { Authorization: "Basic dXNlcjpwYXNz" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("Bearer プレフィックスのみでトークンが無い場合は 401", async () => {
+      vi.mocked(jwtVerify).mockRejectedValueOnce(new Error("invalid token"));
+      const res = await app.request("/tasks", {
+        headers: { Authorization: "Bearer " },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("JWT 検証に失敗した場合は 401", async () => {
+      vi.mocked(jwtVerify).mockRejectedValueOnce(new Error("invalid token"));
+      const res = await app.request("/tasks", {
+        headers: { Authorization: "Bearer tampered.jwt.token" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("JWT に sub クレームが無い場合は 401", async () => {
+      vi.mocked(jwtVerify).mockResolvedValueOnce({
+        payload: {},
+      } as never);
+      const res = await app.request("/tasks", {
+        headers: { Authorization: "Bearer no-sub-token" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("401 レスポンスに WWW-Authenticate: Bearer ヘッダが含まれる", async () => {
+      const res = await app.request("/tasks");
+      expect(res.headers.get("WWW-Authenticate")).toBe("Bearer");
+    });
+
+    it("認証失敗時にデータが作成されないこと（POST /categories）", async () => {
+      await app.request("/categories", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Should not save", color: "#000000" }),
+      });
+
+      const count = await prisma.category.count();
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("IDOR（他ユーザーのデータへのアクセス）", () => {
+    it("リクエストボディに userId を仕込んでも別ユーザーのデータは作れない", async () => {
+      // クライアントが userId を直接指定しようとしても、route 側は JWT の sub を使う
+      const res = await app.request("/categories", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-token",
+        },
+        body: JSON.stringify({
+          name: "Spoofed",
+          color: "#FFFFFF",
+          userId: "victim-user-id",
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+
+      const created = await prisma.category.findUnique({
+        where: { id: body.id },
+      });
+      expect(created?.userId).toBe("test-user-id");
+    });
+
+    it("別ユーザーのタスクに作業記録を紐付けようとすると 404", async () => {
+      const otherCategory = await prisma.category.create({
+        data: { name: "Work", color: "#0000FF", userId: "other-user-id" },
+      });
+      const otherTask = await prisma.task.create({
+        data: {
+          name: "Victim task",
+          categoryId: otherCategory.id,
+          status: "todo",
+          isNext: false,
+          userId: "other-user-id",
+        },
+      });
+
+      const res = await app.request("/work-records", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-token",
+        },
+        body: JSON.stringify({
+          taskId: otherTask.id,
+          date: "2026-04-19",
+          durationMinutes: 30,
+          result: "completed",
+        }),
+      });
+
+      expect(res.status).toBe(404);
+
+      const records = await prisma.workRecord.count({
+        where: { taskId: otherTask.id },
+      });
+      expect(records).toBe(0);
+    });
+  });
+
+  describe("SQL インジェクション", () => {
+    it("name フィールドの SQLi ペイロードは文字列としてそのまま保存される", async () => {
+      const payload = "'; DROP TABLE categories; --";
+
+      const res = await app.request("/categories", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-token",
+        },
+        body: JSON.stringify({ name: payload, color: "#0000FF" }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.name).toBe(payload);
+
+      // テーブルが破壊されていないこと
+      const count = await prisma.category.count();
+      expect(count).toBe(1);
+    });
+
+    it("UUID ライクな SQLi ペイロードを :id に渡すと 400（UUID バリデーションで弾く）", async () => {
+      const payload = "00000000-0000-0000-0000-000000000000' OR '1'='1";
+
+      const res = await app.request(
+        `/categories/${encodeURIComponent(payload)}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: "Bearer test-token" },
+        },
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it("タスク名に改行・特殊文字を含むペイロードを送っても 201 で文字列保存される", async () => {
+      // 注: NULL バイト (\u0000) は Postgres TEXT 型が拒否するため別挙動になる
+      const payload = "task\nname\rwith<script>alert(1)</script>";
+
+      const res = await app.request("/tasks", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-token",
+        },
+        body: JSON.stringify({
+          name: payload,
+          categoryId: null,
+          estimatedMinutes: null,
+          scheduledDate: null,
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.name).toBe(payload);
+    });
+  });
+
+  describe("境界値", () => {
+    describe("文字列長", () => {
+      it("カテゴリ名 50 文字ちょうどは 201", async () => {
+        const res = await app.request("/categories", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify({
+            name: "a".repeat(50),
+            color: "#0000FF",
+          }),
+        });
+        expect(res.status).toBe(201);
+      });
+
+      it("カテゴリ名 51 文字は 400", async () => {
+        const res = await app.request("/categories", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify({
+            name: "a".repeat(51),
+            color: "#0000FF",
+          }),
+        });
+        expect(res.status).toBe(400);
+      });
+
+      it("タスク名が 10000 文字（極端に大きな値）は 400", async () => {
+        const res = await app.request("/tasks", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify({
+            name: "a".repeat(10000),
+            categoryId: null,
+            estimatedMinutes: null,
+            scheduledDate: null,
+          }),
+        });
+        expect(res.status).toBe(400);
+      });
+    });
+
+    describe("数値", () => {
+      it("estimatedMinutes = 0 は 400 (positive 制約)", async () => {
+        const res = await app.request("/tasks", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify({
+            name: "Task",
+            categoryId: null,
+            estimatedMinutes: 0,
+            scheduledDate: null,
+          }),
+        });
+        expect(res.status).toBe(400);
+      });
+
+      it("estimatedMinutes が負の値は 400", async () => {
+        const res = await app.request("/tasks", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify({
+            name: "Task",
+            categoryId: null,
+            estimatedMinutes: -1,
+            scheduledDate: null,
+          }),
+        });
+        expect(res.status).toBe(400);
+      });
+
+      it("estimatedMinutes が小数は 400 (int 制約)", async () => {
+        const res = await app.request("/tasks", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify({
+            name: "Task",
+            categoryId: null,
+            estimatedMinutes: 1.5,
+            scheduledDate: null,
+          }),
+        });
+        expect(res.status).toBe(400);
+      });
+
+      it("estimatedMinutes が極端に大きい値 (Number.MAX_SAFE_INTEGER) は 201（int 範囲内）", async () => {
+        // 現状スキーマに上限が無いため、巨大な値が通る挙動を検証する
+        // 業務的に上限を入れたい場合は別途 issue 化対象
+        const res = await app.request("/tasks", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify({
+            name: "Task",
+            categoryId: null,
+            estimatedMinutes: Number.MAX_SAFE_INTEGER,
+            scheduledDate: null,
+          }),
+        });
+        // Postgres Int は 2^31-1 までなので、Prisma 層で失敗する可能性がある
+        expect([201, 400, 500]).toContain(res.status);
+      });
+    });
+
+    describe("空文字列", () => {
+      it("カテゴリ color が空文字は 400", async () => {
+        const res = await app.request("/categories", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify({ name: "Work", color: "" }),
+        });
+        expect(res.status).toBe(400);
+      });
+
+      it("タスク作成時の name が半角スペースのみは 400 を期待するが、現状は 201（空白 trim をしていない）", async () => {
+        // 期待: 空白のみは無効入力。
+        // 現状: zod の min(1) は空白を許容する。改善候補。
+        const res = await app.request("/tasks", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify({
+            name: "   ",
+            categoryId: null,
+            estimatedMinutes: null,
+            scheduledDate: null,
+          }),
+        });
+        // 現状の挙動を記録（リグレッション検知用）
+        expect(res.status).toBe(201);
+      });
+    });
+  });
+});

--- a/apps/api/src/__tests__/attack-vectors.test.ts
+++ b/apps/api/src/__tests__/attack-vectors.test.ts
@@ -328,9 +328,7 @@ describe("セキュリティ - 攻撃シナリオ", () => {
         expect(res.status).toBe(400);
       });
 
-      it("estimatedMinutes が極端に大きい値 (Number.MAX_SAFE_INTEGER) は 201（int 範囲内）", async () => {
-        // 現状スキーマに上限が無いため、巨大な値が通る挙動を検証する
-        // 業務的に上限を入れたい場合は別途 issue 化対象
+      it("estimatedMinutes が極端に大きい値 (Number.MAX_SAFE_INTEGER) は 400 (max 制約)", async () => {
         const res = await app.request("/tasks", {
           method: "POST",
           headers: {
@@ -344,8 +342,41 @@ describe("セキュリティ - 攻撃シナリオ", () => {
             scheduledDate: null,
           }),
         });
-        // Postgres Int は 2^31-1 までなので、Prisma 層で失敗する可能性がある
-        expect([201, 400, 500]).toContain(res.status);
+        expect(res.status).toBe(400);
+      });
+
+      it("estimatedMinutes 上限値 (1440 = 24時間) ちょうどは 201", async () => {
+        const res = await app.request("/tasks", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify({
+            name: "Task",
+            categoryId: null,
+            estimatedMinutes: 1440,
+            scheduledDate: null,
+          }),
+        });
+        expect(res.status).toBe(201);
+      });
+
+      it("estimatedMinutes 上限値超え (1441) は 400", async () => {
+        const res = await app.request("/tasks", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+          },
+          body: JSON.stringify({
+            name: "Task",
+            categoryId: null,
+            estimatedMinutes: 1441,
+            scheduledDate: null,
+          }),
+        });
+        expect(res.status).toBe(400);
       });
     });
 
@@ -362,9 +393,7 @@ describe("セキュリティ - 攻撃シナリオ", () => {
         expect(res.status).toBe(400);
       });
 
-      it("タスク作成時の name が半角スペースのみは 400 を期待するが、現状は 201（空白 trim をしていない）", async () => {
-        // 期待: 空白のみは無効入力。
-        // 現状: zod の min(1) は空白を許容する。改善候補。
+      it("タスク作成時の name が空白のみは 400 (trim 後 min(1))", async () => {
         const res = await app.request("/tasks", {
           method: "POST",
           headers: {
@@ -378,8 +407,7 @@ describe("セキュリティ - 攻撃シナリオ", () => {
             scheduledDate: null,
           }),
         });
-        // 現状の挙動を記録（リグレッション検知用）
-        expect(res.status).toBe(201);
+        expect(res.status).toBe(400);
       });
     });
   });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -37,6 +37,11 @@ const app = new Hono()
     }),
   )
   .use("/*", requestLoggerMiddleware)
+  .use("/*", async (c, next) => {
+    await next();
+    // 認証必須 API のレスポンスがブラウザ・中間キャッシュに残らないようにする
+    c.header("Cache-Control", "no-store, private");
+  })
   .use("/*", authMiddleware)
   .route("/tasks", tasksRoute)
   .route("/categories", categoriesRoute)

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -38,9 +38,11 @@ const app = new Hono()
   )
   .use("/*", requestLoggerMiddleware)
   .use("/*", async (c, next) => {
-    await next();
-    // 認証必須 API のレスポンスがブラウザ・中間キャッシュに残らないようにする
+    // 認証必須 API のレスポンスがブラウザ・中間キャッシュに残らないようにする。
+    // 例外で onError 経路に流れた場合も header を確実に付けるため、
+    // next() の前に設定する（context のヘッダは最終 Response にマージされる）。
     c.header("Cache-Control", "no-store, private");
+    await next();
   })
   .use("/*", authMiddleware)
   .route("/tasks", tasksRoute)

--- a/apps/api/src/features/categories/__tests__/categories.test.ts
+++ b/apps/api/src/features/categories/__tests__/categories.test.ts
@@ -72,6 +72,7 @@ describe("カテゴリ API", () => {
         headers: { Authorization: "Bearer test-token" },
       });
 
+      expect(res.status).toBe(200);
       expect(res.headers.get("Cache-Control")).toBe("no-store, private");
     });
   });

--- a/apps/api/src/features/categories/__tests__/categories.test.ts
+++ b/apps/api/src/features/categories/__tests__/categories.test.ts
@@ -66,6 +66,14 @@ describe("カテゴリ API", () => {
         "http://localhost:3000",
       );
     });
+
+    it("Cache-Control: no-store, private を返す", async () => {
+      const res = await app.request("/categories", {
+        headers: { Authorization: "Bearer test-token" },
+      });
+
+      expect(res.headers.get("Cache-Control")).toBe("no-store, private");
+    });
   });
 
   describe("OPTIONS /categories", () => {

--- a/packages/schema/src/primitives.ts
+++ b/packages/schema/src/primitives.ts
@@ -1,12 +1,17 @@
 import { z } from "zod";
 
+// 1日 = 1440分。実用的なタスク見積もり・作業記録の上限として採用
+export const MAX_DURATION_MINUTES = 1440;
+
 export const taskNameSchema = z
   .string()
+  .trim()
   .min(1, "タスク名を入力してください")
   .max(100, "タスク名は100文字以内で入力してください");
 
 export const categoryNameSchema = z
   .string()
+  .trim()
   .min(1, "カテゴリ名を入力してください")
   .max(50, "カテゴリ名は50文字以内で入力してください");
 
@@ -22,4 +27,5 @@ export const estimatedMinutesSchema = z
   .number("見積もり時間を正しく選択してください")
   .int("見積もり時間を正しく選択してください")
   .positive("見積もり時間を正しく選択してください")
+  .max(MAX_DURATION_MINUTES, "見積もり時間を正しく選択してください")
   .nullable();

--- a/packages/schema/src/primitives.ts
+++ b/packages/schema/src/primitives.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
-// 1日 = 1440分。実用的なタスク見積もり・作業記録の上限として採用
-export const MAX_DURATION_MINUTES = 1440;
+// タスクの見積もり時間（user 入力）の上限。1日 = 1440分。
+// 注: 実経過時間（work-record の durationMinutes 等）には適用しない。
+// 経過時間は日跨ぎや長時間放置で 1440 を超えうるため、サーバ側で弾くと
+// timer 完了 / リカバリーフローが詰む。
+export const MAX_ESTIMATED_MINUTES = 1440;
 
 export const taskNameSchema = z
   .string()
@@ -27,5 +30,5 @@ export const estimatedMinutesSchema = z
   .number("見積もり時間を正しく選択してください")
   .int("見積もり時間を正しく選択してください")
   .positive("見積もり時間を正しく選択してください")
-  .max(MAX_DURATION_MINUTES, "見積もり時間を正しく選択してください")
+  .max(MAX_ESTIMATED_MINUTES, "見積もり時間を正しく選択してください")
   .nullable();

--- a/packages/schema/src/timer-session.ts
+++ b/packages/schema/src/timer-session.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
-import { MAX_DURATION_MINUTES } from "./primitives";
+import { MAX_ESTIMATED_MINUTES } from "./primitives";
 
 export const createTimerSessionSchema = z.object({
   taskId: z.uuid(),
   taskName: z.string().min(1),
   categoryName: z.string(),
-  estimatedMinutes: z.number().int().positive().max(MAX_DURATION_MINUTES),
+  estimatedMinutes: z.number().int().positive().max(MAX_ESTIMATED_MINUTES),
 });
 
 export const timerSessionResponseSchema = z.object({

--- a/packages/schema/src/timer-session.ts
+++ b/packages/schema/src/timer-session.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
+import { MAX_DURATION_MINUTES } from "./primitives";
 
 export const createTimerSessionSchema = z.object({
   taskId: z.uuid(),
   taskName: z.string().min(1),
   categoryName: z.string(),
-  estimatedMinutes: z.number().int().positive(),
+  estimatedMinutes: z.number().int().positive().max(MAX_DURATION_MINUTES),
 });
 
 export const timerSessionResponseSchema = z.object({

--- a/packages/schema/src/timer-session.ts
+++ b/packages/schema/src/timer-session.ts
@@ -1,11 +1,20 @@
 import { z } from "zod";
-import { MAX_ESTIMATED_MINUTES } from "./primitives";
+import { MAX_ESTIMATED_MINUTES, taskNameSchema } from "./primitives";
+
+// 注: categoryName は未分類タスクのため空文字を許容する仕様。
+// `categoryNameSchema` は trim + min(1) を要求するため再利用しない。
+// 過剰長だけは categoryNameSchema と同じ 50 文字でガードする。
+const CATEGORY_NAME_MAX = 50;
 
 export const createTimerSessionSchema = z.object({
   taskId: z.uuid(),
-  taskName: z.string().min(1),
-  categoryName: z.string(),
-  estimatedMinutes: z.number().int().positive().max(MAX_ESTIMATED_MINUTES),
+  taskName: taskNameSchema,
+  categoryName: z.string().max(CATEGORY_NAME_MAX),
+  estimatedMinutes: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_ESTIMATED_MINUTES, "見積もり時間を正しく選択してください"),
 });
 
 export const timerSessionResponseSchema = z.object({

--- a/packages/schema/src/work-record.ts
+++ b/packages/schema/src/work-record.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
+import { MAX_DURATION_MINUTES } from "./primitives";
 
 const workResultEnum = z.enum(["completed", "interrupted"]);
 
 export const createWorkRecordSchema = z.object({
   taskId: z.uuid(),
   date: z.iso.date(),
-  durationMinutes: z.number().int().min(0),
+  durationMinutes: z.number().int().min(0).max(MAX_DURATION_MINUTES),
   result: workResultEnum,
 });
 

--- a/packages/schema/src/work-record.ts
+++ b/packages/schema/src/work-record.ts
@@ -1,12 +1,15 @@
 import { z } from "zod";
-import { MAX_DURATION_MINUTES } from "./primitives";
 
 const workResultEnum = z.enum(["completed", "interrupted"]);
 
+// durationMinutes は実経過時間（クライアント側で `Date.now() - startedAt` を計算）。
+// 日跨ぎ・長時間放置・recovery dialog 経由で 1440 を超えうるため、
+// サーバ側で上限を弾くと timer 完了 / リカバリーフローが詰む（work-record が
+// 保存できず timer session も clear されない）。よって上限は設けない。
 export const createWorkRecordSchema = z.object({
   taskId: z.uuid(),
   date: z.iso.date(),
-  durationMinutes: z.number().int().min(0).max(MAX_DURATION_MINUTES),
+  durationMinutes: z.number().int().min(0),
   result: workResultEnum,
 });
 


### PR DESCRIPTION
## 概要

セキュリティ周りの確認・対策をまとめて実施。

注: ブルートフォース対策（#78）はこの PR の対象外。Supabase Auth 側 rate limit / CAPTCHA / MFA の方針決定が必要なため別途対応する。

## 変更内容

### 攻撃対策・防御層
- API レスポンスに `Cache-Control: no-store, private` を付与（onError 経路もカバー）
- git hook bypass（`--no-verify` / `-n`）を Claude Code / Codex 両方で禁止

### 入力バリデーション強化
- name 系を `trim()` 後 `min(1)` で検証（空白のみを 400 で拒否）
- タスク見積もり時間に上限 (1440分 = 24時間) を追加
- work-record の `durationMinutes` は実経過時間のため上限なし（timer 完了 / リカバリーフローが詰まらないように）

### 攻撃者視点のテスト追加
`apps/api/src/__tests__/attack-vectors.test.ts` に 26 件の横断テストを追加:

- 認証なし / 不正なスキーム / JWT 検証失敗 / sub クレーム欠落
- リクエストボディに `userId` を仕込んでも JWT の sub が優先されること
- SQL インジェクション・特殊文字を含む文字列の安全な保存
- 文字列長・数値の境界値（min/max、0、負数、小数）
- 500 (onError) 経路でも Cache-Control が付くこと

## 確認方法

- [x] `pnpm build` が通る
- [x] `pnpm lint` が通る（pre-commit hook で確認）
- [x] `pnpm test` が通る（api: 134, web: 61 全パス）
- [x] semgrep / gitleaks 検出なし

## 補足

Codex adversarial review を 2 回実施し、指摘を反映:

1. **work-record の 24h cap が timer 完了/recovery を壊す** → `durationMinutes.max()` を撤廃
2. **Cache-Control が onError 経路で抜ける** → `next()` 前に設定
