### PR TITLE
Better Auth 攻撃シナリオテストを追加

### DIFF
--- a/apps/api/src/__tests__/attack-vectors.test.ts
+++ b/apps/api/src/__tests__/attack-vectors.test.ts
@@ -1,13 +1,12 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
-import app from "../app";
-import * as categoryService from "../features/categories/service";
-import { getSession } from "./helpers/auth";
-import { cleanDatabase, prisma } from "./helpers/db";
 
-// 攻撃者視点の横断テスト
-// 認証バイパス、IDOR、SQL インジェクション、境界値の挙動を検証する。
-// 各 feature の通常系・ユーザー隔離テストは `features/*/__tests__/` に存在する前提で、
-// ここでは追加でカバーすべき攻撃シナリオに絞って検証する。
+// vi.mock は hoist 対象。helpers/auth.ts に書かれた vi.mock は、
+// import 順次第で `app` 評価前に走らず mock が効かないことがあるため、
+// 本ファイルでは vi.hoisted + vi.mock を test file 冒頭に直接書く。
+const { getSession } = vi.hoisted(() => ({ getSession: vi.fn() }));
+vi.mock("../shared/auth/auth", () => ({
+  auth: { api: { getSession } },
+}));
 
 // onError 経由の Cache-Control 検証用に list を spy 化（デフォルトは実装を呼ぶ）
 vi.mock("../features/categories/service", async (importOriginal) => {
@@ -18,6 +17,15 @@ vi.mock("../features/categories/service", async (importOriginal) => {
     list: vi.fn().mockImplementation(actual.list),
   };
 });
+
+import app from "../app";
+import * as categoryService from "../features/categories/service";
+import { cleanDatabase, prisma } from "./helpers/db";
+
+// 攻撃者視点の横断テスト
+// 認証バイパス、IDOR、SQL インジェクション、境界値の挙動を検証する。
+// 各 feature の通常系・ユーザー隔離テストは `features/*/__tests__/` に存在する前提で、
+// ここでは追加でカバーすべき攻撃シナリオに絞って検証する。
 
 describe("セキュリティ - 攻撃シナリオ", () => {
   beforeEach(async () => {

--- a/apps/api/src/__tests__/auth-attack-vectors.test.ts
+++ b/apps/api/src/__tests__/auth-attack-vectors.test.ts
@@ -254,6 +254,19 @@ describe("Better Auth - 攻撃シナリオ", () => {
       expect(res.status).toBe(401);
     });
 
+    it("Origin ヘッダなしの sign-out は 403 (Better Auth の origin check)", async () => {
+      // 注: Web 側の `signOutServerSession` はこの挙動を踏まえ Origin を補完する。
+      // ここでは Better Auth 側の生挙動を明文化する。
+      const signUpRes = await signUp();
+      const cookie = extractSessionCookie(signUpRes);
+
+      const res = await app.request("/api/auth/sign-out", {
+        method: "POST",
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(403);
+    });
+
     it("DB から session を直接削除すると、その cookie は無効化される", async () => {
       const signUpRes = await signUp();
       const cookie = extractSessionCookie(signUpRes);

--- a/apps/api/src/__tests__/auth-attack-vectors.test.ts
+++ b/apps/api/src/__tests__/auth-attack-vectors.test.ts
@@ -1,0 +1,386 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import app from "../app";
+import { cleanDatabase, prisma } from "./helpers/db";
+
+// Better Auth 自体への攻撃シナリオ。
+// 通常の attack-vectors.test.ts は getSession を mock するが、
+// このファイルは mock を使わず実際の Better Auth handler を直接叩く。
+
+const VALID_PASSWORD = "password123";
+const VALID_EMAIL = "user@example.com";
+const VALID_NAME = "User";
+const TRUSTED_ORIGIN = "http://localhost:3000";
+
+async function signUp({
+  email = VALID_EMAIL,
+  password = VALID_PASSWORD,
+  name = VALID_NAME,
+  origin = TRUSTED_ORIGIN,
+}: {
+  email?: string;
+  password?: string;
+  name?: string;
+  origin?: string;
+} = {}) {
+  return app.request("/api/auth/sign-up/email", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: origin,
+    },
+    body: JSON.stringify({ email, password, name }),
+  });
+}
+
+async function signIn({
+  email = VALID_EMAIL,
+  password = VALID_PASSWORD,
+  origin = TRUSTED_ORIGIN,
+}: {
+  email?: string;
+  password?: string;
+  origin?: string;
+} = {}) {
+  return app.request("/api/auth/sign-in/email", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: origin,
+    },
+    body: JSON.stringify({ email, password }),
+  });
+}
+
+function extractSessionCookie(res: Response): string {
+  const cookies = res.headers.getSetCookie?.() ?? [];
+  const sessionCookie = cookies.find((c) =>
+    c.startsWith("better-auth.session_token="),
+  );
+  if (!sessionCookie) {
+    throw new Error(
+      `No session cookie in response. cookies=${JSON.stringify(cookies)}`,
+    );
+  }
+  // Cookie 名=値 部分のみを取り出す
+  return sessionCookie.split(";")[0]!;
+}
+
+describe("Better Auth - 攻撃シナリオ", () => {
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  afterAll(async () => {
+    await cleanDatabase();
+    await prisma.$disconnect();
+  });
+
+  describe("サインアップ", () => {
+    it("有効な入力でアカウント作成できる (200)", async () => {
+      const res = await signUp();
+      expect(res.status).toBe(200);
+    });
+
+    it("パスワードが minPasswordLength (6) 未満は拒否される", async () => {
+      const res = await signUp({ password: "12345" });
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+    });
+
+    it("パスワード境界値 (6 文字ちょうど) は受理される", async () => {
+      const res = await signUp({ password: "abc123" });
+      expect(res.status).toBe(200);
+    });
+
+    it("空のパスワードは拒否される", async () => {
+      const res = await signUp({ password: "" });
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+    });
+
+    it("不正な email フォーマットは拒否される", async () => {
+      const res = await signUp({ email: "not-an-email" });
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+    });
+
+    it("既存メールアドレスでの重複登録は失敗する", async () => {
+      const first = await signUp();
+      expect(first.status).toBe(200);
+
+      const second = await signUp();
+      expect(second.status).toBeGreaterThanOrEqual(400);
+      expect(second.status).toBeLessThan(500);
+
+      const count = await prisma.user.count();
+      expect(count).toBe(1);
+    });
+
+    it("email に SQL インジェクションペイロードを入れても DB は壊れない", async () => {
+      // 不正フォーマットなので 400 になる想定だが、いずれにせよ user テーブルは健全
+      await signUp({ email: 'user@example.com\'; DROP TABLE "user"; --' });
+
+      // テーブル自体が存在し続けることを確認
+      await expect(prisma.user.count()).resolves.toBeGreaterThanOrEqual(0);
+    });
+
+    it("極端に長い name (10000 文字) でも 5xx で落ちない", async () => {
+      const res = await signUp({ name: "a".repeat(10000) });
+      // accept (200) でも reject (4xx) でも構わないが、500 系で落ちるのは NG
+      expect(res.status).toBeLessThan(500);
+    });
+  });
+
+  describe("サインイン (account enumeration / brute force 関連)", () => {
+    beforeEach(async () => {
+      await signUp();
+    });
+
+    it("正しい資格情報でサインイン成功", async () => {
+      const res = await signIn();
+      expect(res.status).toBe(200);
+    });
+
+    it("間違ったパスワードは 401", async () => {
+      const res = await signIn({ password: "wrongpassword" });
+      expect(res.status).toBe(401);
+    });
+
+    it("存在しないユーザーは 401", async () => {
+      const res = await signIn({
+        email: "nobody@example.com",
+        password: VALID_PASSWORD,
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("account enumeration 対策: 存在しないユーザーと間違ったパスワードのレスポンスが同一", async () => {
+      const wrongPassword = await signIn({ password: "wrongpassword" });
+      const noUser = await signIn({
+        email: "nobody@example.com",
+        password: VALID_PASSWORD,
+      });
+
+      // status / body / code いずれもユーザー存在を漏らしてはならない
+      expect(wrongPassword.status).toBe(noUser.status);
+
+      const wrongBody = (await wrongPassword.json()) as {
+        message?: string;
+        code?: string;
+      };
+      const noUserBody = (await noUser.json()) as {
+        message?: string;
+        code?: string;
+      };
+      expect(wrongBody.message).toBe(noUserBody.message);
+      expect(wrongBody.code).toBe(noUserBody.code);
+    });
+
+    it("空のパスワードでサインインは失敗する", async () => {
+      const res = await signIn({ password: "" });
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+    });
+
+    it("email に SQL インジェクションを入れてもログイン成功しない", async () => {
+      const res = await signIn({
+        email: "' OR '1'='1",
+        password: VALID_PASSWORD,
+      });
+      // 不正 email として 4xx になる前提。少なくとも 200 では決して通さない
+      expect(res.status).not.toBe(200);
+    });
+  });
+
+  describe("セッション cookie の属性", () => {
+    it("sign-up 時の Set-Cookie が HttpOnly / SameSite=Lax / Path=/ を含む", async () => {
+      const res = await signUp();
+      const cookies = res.headers.getSetCookie?.() ?? [];
+      const sessionCookie = cookies.find((c) =>
+        c.startsWith("better-auth.session_token="),
+      );
+      expect(sessionCookie).toBeDefined();
+      expect(sessionCookie).toMatch(/HttpOnly/i);
+      expect(sessionCookie).toMatch(/SameSite=Lax/i);
+      expect(sessionCookie).toMatch(/Path=\//);
+      // 注: Secure 属性は本番（HTTPS）でのみ付くため test では検証しない
+    });
+
+    it("sign-in 時の Set-Cookie も HttpOnly を含む", async () => {
+      await signUp();
+      const res = await signIn();
+      const cookies = res.headers.getSetCookie?.() ?? [];
+      const sessionCookie = cookies.find((c) =>
+        c.startsWith("better-auth.session_token="),
+      );
+      expect(sessionCookie).toBeDefined();
+      expect(sessionCookie).toMatch(/HttpOnly/i);
+    });
+  });
+
+  describe("セッション検証 / 無効化", () => {
+    it("sign-up で得た cookie で /tasks にアクセスできる (200)", async () => {
+      const signUpRes = await signUp();
+      const cookie = extractSessionCookie(signUpRes);
+
+      const res = await app.request("/tasks", { headers: { Cookie: cookie } });
+      expect(res.status).toBe(200);
+    });
+
+    it("改ざんしたセッショントークンは 401", async () => {
+      const signUpRes = await signUp();
+      const cookie = extractSessionCookie(signUpRes);
+      // 末尾を 1 文字書き換える
+      const tamperedCookie = `${cookie.slice(0, -1)}X`;
+
+      const res = await app.request("/tasks", {
+        headers: { Cookie: tamperedCookie },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("sign-out 後の cookie は無効化される (再利用で 401)", async () => {
+      const signUpRes = await signUp();
+      const cookie = extractSessionCookie(signUpRes);
+
+      const signOutRes = await app.request("/api/auth/sign-out", {
+        method: "POST",
+        headers: { Cookie: cookie, Origin: TRUSTED_ORIGIN },
+      });
+      expect(signOutRes.status).toBe(200);
+
+      // 同じ cookie で再アクセス
+      const res = await app.request("/tasks", { headers: { Cookie: cookie } });
+      expect(res.status).toBe(401);
+    });
+
+    it("DB から session を直接削除すると、その cookie は無効化される", async () => {
+      const signUpRes = await signUp();
+      const cookie = extractSessionCookie(signUpRes);
+
+      // DB から全 session を削除
+      await prisma.session.deleteMany();
+
+      const res = await app.request("/tasks", { headers: { Cookie: cookie } });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("get-session", () => {
+    it("cookie なしの get-session は空 body (null) を返す", async () => {
+      const res = await app.request("/api/auth/get-session");
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      // null または空文字
+      expect(body === "" || body === "null").toBe(true);
+    });
+
+    it("不正 cookie の get-session は空 body (null) を返す", async () => {
+      const res = await app.request("/api/auth/get-session", {
+        headers: { Cookie: "better-auth.session_token=invalid.signature" },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body === "" || body === "null").toBe(true);
+    });
+
+    it("正しい cookie の get-session は user 情報を返す", async () => {
+      const signUpRes = await signUp();
+      const cookie = extractSessionCookie(signUpRes);
+
+      const res = await app.request("/api/auth/get-session", {
+        headers: { Cookie: cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        user?: { email?: string };
+      } | null;
+      expect(body?.user?.email).toBe(VALID_EMAIL);
+    });
+  });
+
+  describe("CSRF / trustedOrigins", () => {
+    // Better Auth の Origin 検証は cookie が付いている or Sec-Fetch-* ヘッダが
+    // ある場合に限って走る（攻撃成立条件を満たすブラウザ起点の場合のみ）。
+    // 単純な server-to-server POST（cookie/Sec-Fetch なし）は通すが、その場合
+    // 認証 cookie が無いため攻撃にはならない。
+
+    it("trusted な Origin (http://localhost:3000) からの sign-in は受理される", async () => {
+      await signUp();
+      const res = await signIn({ origin: "http://localhost:3000" });
+      expect(res.status).toBe(200);
+    });
+
+    it("クロスサイトフォーム送信 (Sec-Fetch-Site=cross-site, Mode=navigate) は 403", async () => {
+      await signUp();
+      const res = await app.request("/api/auth/sign-in/email", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://evil.example.com",
+          "Sec-Fetch-Site": "cross-site",
+          "Sec-Fetch-Mode": "navigate",
+        },
+        body: JSON.stringify({
+          email: VALID_EMAIL,
+          password: VALID_PASSWORD,
+        }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("認証 cookie 付き + 信頼されていない Origin からのリクエストは 403 (CSRF)", async () => {
+      const signUpRes = await signUp();
+      const cookie = extractSessionCookie(signUpRes);
+
+      // 既存セッションを持つ被害者ブラウザを攻撃者サイトが踏ませた想定
+      const res = await app.request("/api/auth/sign-in/email", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://evil.example.com",
+          Cookie: cookie,
+        },
+        body: JSON.stringify({
+          email: VALID_EMAIL,
+          password: VALID_PASSWORD,
+        }),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("ユーザー隔離 (認証経由)", () => {
+    it("user A の cookie で API にアクセスしても user B のデータは見えない", async () => {
+      // user A
+      const signUpA = await signUp({ email: "a@example.com" });
+      const cookieA = extractSessionCookie(signUpA);
+      const userAId = ((await signUpA.json()) as { user: { id: string } }).user
+        .id;
+
+      // user B のカテゴリを直接 DB で作成
+      await signUp({ email: "b@example.com" });
+      const userB = await prisma.user.findUniqueOrThrow({
+        where: { email: "b@example.com" },
+      });
+      await prisma.category.create({
+        data: {
+          name: "B's category",
+          color: "#FF0000",
+          userId: userB.id,
+        },
+      });
+
+      // user A としてカテゴリ一覧取得
+      const res = await app.request("/categories", {
+        headers: { Cookie: cookieA },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { name: string }[];
+      expect(body).toEqual([]);
+
+      // 念のため A != B
+      expect(userAId).not.toBe(userB.id);
+    });
+  });
+});

--- a/apps/api/src/shared/auth/auth.ts
+++ b/apps/api/src/shared/auth/auth.ts
@@ -34,4 +34,10 @@ export const auth = betterAuth({
     enabled: true,
     minPasswordLength: 6,
   },
+  advanced: {
+    // Better Auth はデフォルトで NODE_ENV=test の場合に Origin チェックを
+    // スキップするが、攻撃テストや production と同じ挙動を保ちたいため
+    // 明示的に false を指定して常に有効化する。
+    disableOriginCheck: false,
+  },
 });

--- a/apps/web/src/shared/lib/auth/__tests__/server.test.ts
+++ b/apps/web/src/shared/lib/auth/__tests__/server.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { signOutServerSession } from "@/shared/lib/auth/server";
+
+describe("signOutServerSession", () => {
+  const fetchSpy = vi.fn();
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+    fetchSpy.mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("Origin ヘッダがない request でも、Web オリジンを補完して sign-out へ forward する", async () => {
+    const request = new Request(
+      "https://app.example.com/auth/session-expired",
+      {
+        method: "GET",
+        headers: { cookie: "better-auth.session_token=abc" },
+      },
+    );
+
+    await signOutServerSession(request);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get("origin")).toBe("https://app.example.com");
+    expect(headers.get("cookie")).toBe("better-auth.session_token=abc");
+  });
+
+  it("Origin ヘッダが既にある場合は上書きしない", async () => {
+    const request = new Request(
+      "https://app.example.com/auth/session-expired",
+      {
+        method: "POST",
+        headers: {
+          cookie: "better-auth.session_token=abc",
+          origin: "https://other.example.com",
+        },
+      },
+    );
+
+    await signOutServerSession(request);
+
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get("origin")).toBe("https://other.example.com");
+  });
+});

--- a/apps/web/src/shared/lib/auth/server.ts
+++ b/apps/web/src/shared/lib/auth/server.ts
@@ -40,9 +40,18 @@ export async function getServerAuthSession(
 }
 
 export async function signOutServerSession(request: Request) {
+  // Better Auth は cookie 付き POST に対して Origin ヘッダを検証し、
+  // 欠落 / 信頼外なら 403 を返して sign-out が成立しない。
+  // session-expired は GET ナビゲーション経由で呼ばれ Origin を持たない
+  // ことが多いため、現在の Web オリジンを明示的に forward する。
+  const forwardedHeaders = new Headers(request.headers);
+  if (!forwardedHeaders.has("origin")) {
+    forwardedHeaders.set("origin", new URL(request.url).origin);
+  }
+
   return fetch(`${getApiBaseUrl()}/api/auth/sign-out`, {
     method: "POST",
-    headers: request.headers,
+    headers: forwardedHeaders,
     cache: "no-store",
   });
 }


### PR DESCRIPTION
## 概要

Better Auth 移行を受けて、認証エンドポイント自体への攻撃シナリオテストを追加。Supabase 時代は外部 SaaS が認証を持っていたためアプリ側で検証可能なのは JWT 検証のみだったが、Better Auth で認証ロジックがアプリ内に来たため攻撃面が大幅に広がった。

closes #

## 変更内容

### 新規テスト: `apps/api/src/__tests__/auth-attack-vectors.test.ts` (27 件)

`auth.api.getSession` を mock せず実際の Better Auth handler を直接叩く形で検証:

- **サインアップ**: 短すぎるパスワード / 既存メール重複 / 不正フォーマット / SQL インジェクション / 極端に長い name
- **サインイン**: 間違ったパスワード / 存在しないユーザー / **account enumeration 対策**（status / message / code が完全一致）/ SQL インジェクション
- **セッション cookie 属性**: `HttpOnly` / `SameSite=Lax` / `Path=/`
- **セッション無効化**: 改ざんトークン / sign-out 後の再利用 / DB 直接削除
- **get-session**: 不正 cookie / 正しい cookie の挙動
- **CSRF**: cross-site form submit (`Sec-Fetch-Site=cross-site`, `Mode=navigate`) / 認証 cookie + 非 trusted Origin
- **ユーザー隔離**: A の cookie で B のデータが見えない（authMiddleware → getSession → userId スコープ）

### 副次修正

1. **`auth.ts` に `advanced.disableOriginCheck: false` を明示指定**
   Better Auth はデフォルトで `NODE_ENV=test` の場合に Origin チェックを自動的にスキップする (`isTest() ? true : false`)。攻撃テストや production と同じ挙動を保ちたいため明示的に false 指定。
2. **`attack-vectors.test.ts` の `vi.mock` を `vi.hoisted` で test file 冒頭に hoist**
   `helpers/auth.ts` 経由の `vi.mock` は import 順次第で `app` 評価前に走らず mock が効かない問題があった（main で 17 件失敗していた既存リグレッション）。

## 確認方法

- [x] `pnpm build` が通る
- [x] `pnpm test` が通る (api: 161, web: 65 全 pass)
- [x] gitleaks / semgrep 検出なし

## 補足

CSRF テストの実装にあたり Better Auth の origin check 内部実装を確認:
- cookie あり または `Sec-Fetch-*` ヘッダありの場合のみ Origin 検証が走る
- script からの直接呼び出し（cookie なし & Sec-Fetch なし）は通すが、認証 cookie が無いため攻撃にはならない
- 実ブラウザの攻撃シナリオ 2 種類を再現: cross-site form submit / 既存セッション乗っ取り
