### PR TITLE
Better Auth に失敗 5 回でアカウント一時ロックする hooks を追加

### DIFF
--- a/apps/api/prisma/migrations/20260428000000_add_account_lockout/migration.sql
+++ b/apps/api/prisma/migrations/20260428000000_add_account_lockout/migration.sql
@@ -1,0 +1,5 @@
+-- ログイン失敗回数ベースのアカウントロック用カラムを追加
+ALTER TABLE "user"
+  ADD COLUMN "failed_login_attempts" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "last_failed_login_at" TIMESTAMP(3),
+  ADD COLUMN "locked_until" TIMESTAMP(3);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -22,15 +22,19 @@ enum WorkResult {
 }
 
 model User {
-  id            String    @id
-  name          String
-  email         String    @unique
-  emailVerified Boolean   @default(false) @map("email_verified")
-  image         String?
-  createdAt     DateTime  @default(now()) @map("created_at")
-  updatedAt     DateTime  @updatedAt @map("updated_at")
-  sessions      Session[]
-  accounts      Account[]
+  id                  String    @id
+  name                String
+  email               String    @unique
+  emailVerified       Boolean   @default(false) @map("email_verified")
+  image               String?
+  createdAt           DateTime  @default(now()) @map("created_at")
+  updatedAt           DateTime  @updatedAt @map("updated_at")
+  // ログイン失敗回数ベースのアカウントロック用
+  failedLoginAttempts Int       @default(0) @map("failed_login_attempts")
+  lastFailedLoginAt   DateTime? @map("last_failed_login_at")
+  lockedUntil         DateTime? @map("locked_until")
+  sessions            Session[]
+  accounts            Account[]
 
   @@map("user")
 }

--- a/apps/api/src/__tests__/auth-attack-vectors.test.ts
+++ b/apps/api/src/__tests__/auth-attack-vectors.test.ts
@@ -575,6 +575,38 @@ describe("Better Auth - 攻撃シナリオ", () => {
       expect(after.lockedUntil!.getTime()).toBe(lockedUntilAtFirstLock);
     });
 
+    it("資格情報不一致以外のエラー (Origin 違反による 403) ではカウントが増えない", async () => {
+      // beforeEach で signUp 済みのアカウントで、まず正しく signin して cookie を取る
+      // (Better Auth の origin check は cookie 付き or Sec-Fetch-* 付きのときだけ走るため)
+      const signInRes = await signIn();
+      const cookie = extractSessionCookie(signInRes);
+
+      // 信頼されていない Origin から正しい資格情報で 5 回試行 → 全て 403
+      for (let i = 0; i < 5; i++) {
+        const res = await app.request("/api/auth/sign-in/email", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: "https://evil.example.com",
+            Cookie: cookie,
+          },
+          body: JSON.stringify({
+            email: VALID_EMAIL,
+            password: VALID_PASSWORD,
+          }),
+        });
+        expect(res.status).toBe(403);
+      }
+
+      const user = await prisma.user.findUniqueOrThrow({
+        where: { email: VALID_EMAIL },
+        select: { failedLoginAttempts: true, lockedUntil: true },
+      });
+      // 資格情報エラーではない以上、ロックカウンタは 0 のまま
+      expect(user.failedLoginAttempts).toBe(0);
+      expect(user.lockedUntil).toBeNull();
+    });
+
     it("複数ユーザーのロックは独立しており、相互に影響しない", async () => {
       const otherEmail = "other@example.com";
       await signUp({ email: otherEmail });

--- a/apps/api/src/__tests__/auth-attack-vectors.test.ts
+++ b/apps/api/src/__tests__/auth-attack-vectors.test.ts
@@ -368,24 +368,65 @@ describe("Better Auth - 攻撃シナリオ", () => {
       await signUp();
     });
 
-    it("失敗5回まではロックされず、6回目以降は 403 ACCOUNT_LOCKED が返る", async () => {
-      // 5回目までは 401 (失敗カウントは積まれるがロックは発動しない)
+    it("失敗5回まではロックされず、6回目以降も外向きには通常の 401 INVALID_EMAIL_OR_PASSWORD を返す", async () => {
       for (let i = 0; i < 5; i++) {
         const res = await signIn({ password: "wrongpassword" });
         expect(res.status).toBe(401);
       }
 
-      // 6回目以降はロック中なので 403
+      // 6回目以降はロック中だが、enumeration 防止のため 401 + INVALID_EMAIL_OR_PASSWORD で返す
       const sixth = await signIn({ password: "wrongpassword" });
-      expect(sixth.status).toBe(403);
+      expect(sixth.status).toBe(401);
       const body = (await sixth.json()) as { code?: string };
-      expect(body.code).toBe("ACCOUNT_LOCKED");
+      expect(body.code).toBe("INVALID_EMAIL_OR_PASSWORD");
 
-      // ロック中は正しいパスワードでも入れない
+      // ロック中は正しいパスワードでも入れない (内部ではブロックされる)
       const correct = await signIn();
-      expect(correct.status).toBe(403);
+      expect(correct.status).toBe(401);
       const correctBody = (await correct.json()) as { code?: string };
-      expect(correctBody.code).toBe("ACCOUNT_LOCKED");
+      expect(correctBody.code).toBe("INVALID_EMAIL_OR_PASSWORD");
+    });
+
+    it("ロック中・通常パスワード不一致・存在しないユーザーで status / code / message が完全一致する (enumeration 抑止)", async () => {
+      // 別ユーザーをロック状態にする
+      const lockedEmail = "locked@example.com";
+      await signUp({ email: lockedEmail });
+      for (let i = 0; i < 5; i++) {
+        await signIn({ email: lockedEmail, password: "wrongpassword" });
+      }
+
+      // ロック中ユーザーへの試行
+      const locked = await signIn({
+        email: lockedEmail,
+        password: "wrongpassword",
+      });
+      // 通常のパスワード不一致 (VALID_EMAIL は beforeEach で作成済み)
+      const wrong = await signIn({ password: "wrongpassword" });
+      // 存在しないユーザー
+      const ghost = await signIn({
+        email: "ghost@example.com",
+        password: "wrongpassword",
+      });
+
+      const lockedBody = (await locked.json()) as {
+        message?: string;
+        code?: string;
+      };
+      const wrongBody = (await wrong.json()) as {
+        message?: string;
+        code?: string;
+      };
+      const ghostBody = (await ghost.json()) as {
+        message?: string;
+        code?: string;
+      };
+
+      expect(locked.status).toBe(wrong.status);
+      expect(wrong.status).toBe(ghost.status);
+      expect(lockedBody.code).toBe(wrongBody.code);
+      expect(wrongBody.code).toBe(ghostBody.code);
+      expect(lockedBody.message).toBe(wrongBody.message);
+      expect(wrongBody.message).toBe(ghostBody.message);
     });
 
     it("ロック中は lockedUntil が DB に記録される", async () => {
@@ -429,6 +470,32 @@ describe("Better Auth - 攻撃シナリオ", () => {
       expect(user.lastFailedLoginAt).toBeNull();
     });
 
+    it("cooldown 経過直後の 1 回失敗では再ロックされない (失敗カウンタが 1 から再カウントされる)", async () => {
+      // 5回失敗してロック
+      for (let i = 0; i < 5; i++) {
+        await signIn({ password: "wrongpassword" });
+      }
+      // cooldown 経過をシミュレート
+      await prisma.user.update({
+        where: { email: VALID_EMAIL },
+        data: { lockedUntil: new Date(Date.now() - 1000) },
+      });
+
+      // 1 回失敗してもまだロックされない
+      const res = await signIn({ password: "wrongpassword" });
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { code?: string };
+      expect(body.code).toBe("INVALID_EMAIL_OR_PASSWORD");
+
+      const user = await prisma.user.findUniqueOrThrow({
+        where: { email: VALID_EMAIL },
+        select: { failedLoginAttempts: true, lockedUntil: true },
+      });
+      // before hook で cooldown 経過時にリセット → 今回の失敗で 1 になる
+      expect(user.failedLoginAttempts).toBe(1);
+      expect(user.lockedUntil).toBeNull();
+    });
+
     it("ロック前に成功すると失敗カウンタはリセットされる", async () => {
       // 4回失敗（まだロックされない）
       for (let i = 0; i < 4; i++) {
@@ -461,6 +528,24 @@ describe("Better Auth - 攻撃シナリオ", () => {
         where: { email: "ghost@example.com" },
       });
       expect(ghost).toBeNull();
+    });
+
+    it("並行で失敗 5 回が走ってもカウントが消えず正しく 5 になる (race condition 防止)", async () => {
+      // 5 件並行で失敗 sign-in。read-modify-write が atomic でないと
+      // 同じ初期値を読んで同じ値を書き戻し increment が消える
+      const results = await Promise.all(
+        Array.from({ length: 5 }, () => signIn({ password: "wrongpassword" })),
+      );
+      for (const res of results) {
+        expect(res.status).toBe(401);
+      }
+
+      const user = await prisma.user.findUniqueOrThrow({
+        where: { email: VALID_EMAIL },
+        select: { failedLoginAttempts: true, lockedUntil: true },
+      });
+      expect(user.failedLoginAttempts).toBe(5);
+      expect(user.lockedUntil).not.toBeNull();
     });
   });
 

--- a/apps/api/src/__tests__/auth-attack-vectors.test.ts
+++ b/apps/api/src/__tests__/auth-attack-vectors.test.ts
@@ -81,14 +81,14 @@ describe("Better Auth - 攻撃シナリオ", () => {
       expect(res.status).toBe(200);
     });
 
-    it("パスワードが minPasswordLength (6) 未満は拒否される", async () => {
-      const res = await signUp({ password: "12345" });
+    it("パスワードが minPasswordLength (8) 未満は拒否される", async () => {
+      const res = await signUp({ password: "1234567" });
       expect(res.status).toBeGreaterThanOrEqual(400);
       expect(res.status).toBeLessThan(500);
     });
 
-    it("パスワード境界値 (6 文字ちょうど) は受理される", async () => {
-      const res = await signUp({ password: "abc123" });
+    it("パスワード境界値 (8 文字ちょうど) は受理される", async () => {
+      const res = await signUp({ password: "abc12345" });
       expect(res.status).toBe(200);
     });
 
@@ -360,6 +360,107 @@ describe("Better Auth - 攻撃シナリオ", () => {
         }),
       });
       expect(res.status).toBe(403);
+    });
+  });
+
+  describe("アカウントロック (失敗5回)", () => {
+    beforeEach(async () => {
+      await signUp();
+    });
+
+    it("失敗5回まではロックされず、6回目以降は 403 ACCOUNT_LOCKED が返る", async () => {
+      // 5回目までは 401 (失敗カウントは積まれるがロックは発動しない)
+      for (let i = 0; i < 5; i++) {
+        const res = await signIn({ password: "wrongpassword" });
+        expect(res.status).toBe(401);
+      }
+
+      // 6回目以降はロック中なので 403
+      const sixth = await signIn({ password: "wrongpassword" });
+      expect(sixth.status).toBe(403);
+      const body = (await sixth.json()) as { code?: string };
+      expect(body.code).toBe("ACCOUNT_LOCKED");
+
+      // ロック中は正しいパスワードでも入れない
+      const correct = await signIn();
+      expect(correct.status).toBe(403);
+      const correctBody = (await correct.json()) as { code?: string };
+      expect(correctBody.code).toBe("ACCOUNT_LOCKED");
+    });
+
+    it("ロック中は lockedUntil が DB に記録される", async () => {
+      for (let i = 0; i < 5; i++) {
+        await signIn({ password: "wrongpassword" });
+      }
+      const user = await prisma.user.findUniqueOrThrow({
+        where: { email: VALID_EMAIL },
+        select: { lockedUntil: true, failedLoginAttempts: true },
+      });
+      expect(user.lockedUntil).not.toBeNull();
+      expect(user.lockedUntil!.getTime()).toBeGreaterThan(Date.now());
+      expect(user.failedLoginAttempts).toBeGreaterThanOrEqual(5);
+    });
+
+    it("cooldown 経過後（lockedUntil < now）は再ログインできる", async () => {
+      // 5回失敗してロック
+      for (let i = 0; i < 5; i++) {
+        await signIn({ password: "wrongpassword" });
+      }
+      // lockedUntil を過去に書き換えて cooldown 経過をシミュレート
+      await prisma.user.update({
+        where: { email: VALID_EMAIL },
+        data: { lockedUntil: new Date(Date.now() - 1000) },
+      });
+
+      const res = await signIn();
+      expect(res.status).toBe(200);
+
+      // 成功時にカウンタがリセットされていることを確認
+      const user = await prisma.user.findUniqueOrThrow({
+        where: { email: VALID_EMAIL },
+        select: {
+          failedLoginAttempts: true,
+          lockedUntil: true,
+          lastFailedLoginAt: true,
+        },
+      });
+      expect(user.failedLoginAttempts).toBe(0);
+      expect(user.lockedUntil).toBeNull();
+      expect(user.lastFailedLoginAt).toBeNull();
+    });
+
+    it("ロック前に成功すると失敗カウンタはリセットされる", async () => {
+      // 4回失敗（まだロックされない）
+      for (let i = 0; i < 4; i++) {
+        await signIn({ password: "wrongpassword" });
+      }
+
+      // 正しいパスワードで成功
+      const ok = await signIn();
+      expect(ok.status).toBe(200);
+
+      const user = await prisma.user.findUniqueOrThrow({
+        where: { email: VALID_EMAIL },
+        select: { failedLoginAttempts: true, lastFailedLoginAt: true },
+      });
+      expect(user.failedLoginAttempts).toBe(0);
+      expect(user.lastFailedLoginAt).toBeNull();
+    });
+
+    it("存在しないユーザーには失敗カウンタは記録されない (account enumeration 抑止)", async () => {
+      for (let i = 0; i < 5; i++) {
+        const res = await signIn({
+          email: "ghost@example.com",
+          password: "wrongpassword",
+        });
+        // 401 のまま、ロックには切り替わらない
+        expect(res.status).toBe(401);
+      }
+      // user テーブルには ghost は存在しない
+      const ghost = await prisma.user.findUnique({
+        where: { email: "ghost@example.com" },
+      });
+      expect(ghost).toBeNull();
     });
   });
 

--- a/apps/api/src/__tests__/auth-attack-vectors.test.ts
+++ b/apps/api/src/__tests__/auth-attack-vectors.test.ts
@@ -547,6 +547,65 @@ describe("Better Auth - 攻撃シナリオ", () => {
       expect(user.failedLoginAttempts).toBe(5);
       expect(user.lockedUntil).not.toBeNull();
     });
+
+    it("ロック中の追加失敗でカウントと lockedUntil が変動しない (cooldown 延長されない)", async () => {
+      // 5 回失敗してロック
+      for (let i = 0; i < 5; i++) {
+        await signIn({ password: "wrongpassword" });
+      }
+      const locked = await prisma.user.findUniqueOrThrow({
+        where: { email: VALID_EMAIL },
+        select: { failedLoginAttempts: true, lockedUntil: true },
+      });
+      expect(locked.lockedUntil).not.toBeNull();
+      const lockedUntilAtFirstLock = locked.lockedUntil!.getTime();
+      const attemptsAtFirstLock = locked.failedLoginAttempts;
+
+      // ロック中にさらに 10 回叩いてもカウントも lockedUntil も伸びない
+      for (let i = 0; i < 10; i++) {
+        const res = await signIn({ password: "wrongpassword" });
+        expect(res.status).toBe(401);
+      }
+
+      const after = await prisma.user.findUniqueOrThrow({
+        where: { email: VALID_EMAIL },
+        select: { failedLoginAttempts: true, lockedUntil: true },
+      });
+      expect(after.failedLoginAttempts).toBe(attemptsAtFirstLock);
+      expect(after.lockedUntil!.getTime()).toBe(lockedUntilAtFirstLock);
+    });
+
+    it("複数ユーザーのロックは独立しており、相互に影響しない", async () => {
+      const otherEmail = "other@example.com";
+      await signUp({ email: otherEmail });
+
+      // ユーザー A (VALID_EMAIL) を 5 回失敗でロック
+      for (let i = 0; i < 5; i++) {
+        await signIn({ password: "wrongpassword" });
+      }
+
+      // ユーザー B は依然として正しいパスワードでログインできる
+      const okB = await signIn({ email: otherEmail });
+      expect(okB.status).toBe(200);
+
+      // ユーザー B のカウンタは増えていない
+      const userB = await prisma.user.findUniqueOrThrow({
+        where: { email: otherEmail },
+        select: { failedLoginAttempts: true, lockedUntil: true },
+      });
+      expect(userB.failedLoginAttempts).toBe(0);
+      expect(userB.lockedUntil).toBeNull();
+
+      // ユーザー A は依然としてロック中 (cooldown 経過まで signin 不可)
+      const stillLocked = await signIn();
+      expect(stillLocked.status).toBe(401);
+      const userA = await prisma.user.findUniqueOrThrow({
+        where: { email: VALID_EMAIL },
+        select: { lockedUntil: true },
+      });
+      expect(userA.lockedUntil).not.toBeNull();
+      expect(userA.lockedUntil!.getTime()).toBeGreaterThan(Date.now());
+    });
   });
 
   describe("ユーザー隔離 (認証経由)", () => {

--- a/apps/api/src/shared/auth/auth.ts
+++ b/apps/api/src/shared/auth/auth.ts
@@ -1,5 +1,6 @@
 import { prismaAdapter } from "@better-auth/prisma-adapter";
 import { betterAuth } from "better-auth";
+import { APIError, createAuthMiddleware } from "better-auth/api";
 import { prisma } from "../lib/prisma";
 
 function getAuthBaseUrl() {
@@ -22,6 +23,23 @@ function getTrustedOrigins() {
   ];
 }
 
+// アカウントロック設定
+// - WINDOW_SECONDS 内に LOCK_THRESHOLD 回失敗したら COOLDOWN_SECONDS 間ロック
+// - WINDOW_SECONDS を超える間隔で散発的に失敗するケースは攻撃と見なさずカウンタをリセット
+const LOCK_THRESHOLD = 5;
+const WINDOW_SECONDS = 3600;
+const COOLDOWN_SECONDS = 900;
+const SIGN_IN_PATH = "/sign-in/email";
+const ACCOUNT_LOCKED_CODE = "ACCOUNT_LOCKED";
+const ACCOUNT_LOCKED_MESSAGE =
+  "ログイン失敗が続いたためアカウントを一時的にロックしました。しばらくしてから再度お試しください。";
+
+function getEmailFromBody(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null) return undefined;
+  const email = (body as { email?: unknown }).email;
+  return typeof email === "string" ? email.toLowerCase() : undefined;
+}
+
 export const auth = betterAuth({
   appName: "todo-list",
   baseURL: getAuthBaseUrl(),
@@ -32,12 +50,89 @@ export const auth = betterAuth({
   trustedOrigins: getTrustedOrigins(),
   emailAndPassword: {
     enabled: true,
-    minPasswordLength: 6,
+    minPasswordLength: 8,
   },
   advanced: {
     // Better Auth はデフォルトで NODE_ENV=test の場合に Origin チェックを
     // スキップするが、攻撃テストや production と同じ挙動を保ちたいため
     // 明示的に false を指定して常に有効化する。
     disableOriginCheck: false,
+  },
+  hooks: {
+    // ロック中のユーザーは Better Auth のパスワード検証に到達する前にブロックする
+    before: createAuthMiddleware(async (ctx) => {
+      if (ctx.path !== SIGN_IN_PATH) return;
+      const email = getEmailFromBody(ctx.body);
+      if (!email) return;
+
+      const user = await prisma.user.findUnique({
+        where: { email },
+        select: { lockedUntil: true },
+      });
+      if (!user?.lockedUntil) return;
+      if (user.lockedUntil.getTime() > Date.now()) {
+        throw new APIError("FORBIDDEN", {
+          message: ACCOUNT_LOCKED_MESSAGE,
+          code: ACCOUNT_LOCKED_CODE,
+        });
+      }
+    }),
+    // sign-in の結果に応じて失敗カウンタを更新する
+    after: createAuthMiddleware(async (ctx) => {
+      if (ctx.path !== SIGN_IN_PATH) return;
+      const email = getEmailFromBody(ctx.body);
+      if (!email) return;
+
+      const user = await prisma.user.findUnique({
+        where: { email },
+        select: {
+          id: true,
+          failedLoginAttempts: true,
+          lastFailedLoginAt: true,
+        },
+      });
+      // 存在しないユーザーは account enumeration を避けるため記録しない
+      if (!user) return;
+
+      const returned = ctx.context.returned;
+      const failed = returned instanceof APIError;
+
+      if (!failed) {
+        if (user.failedLoginAttempts === 0 && user.lastFailedLoginAt === null) {
+          return;
+        }
+        await prisma.user.update({
+          where: { id: user.id },
+          data: {
+            failedLoginAttempts: 0,
+            lastFailedLoginAt: null,
+            lockedUntil: null,
+          },
+        });
+        return;
+      }
+
+      // ACCOUNT_LOCKED は before hook で出した自前エラー。二重カウントしない
+      if (returned.body?.code === ACCOUNT_LOCKED_CODE) return;
+
+      const now = new Date();
+      const withinWindow =
+        user.lastFailedLoginAt !== null &&
+        now.getTime() - user.lastFailedLoginAt.getTime() <
+          WINDOW_SECONDS * 1000;
+      const nextAttempts = withinWindow ? user.failedLoginAttempts + 1 : 1;
+      const shouldLock = nextAttempts >= LOCK_THRESHOLD;
+
+      await prisma.user.update({
+        where: { id: user.id },
+        data: {
+          failedLoginAttempts: nextAttempts,
+          lastFailedLoginAt: now,
+          lockedUntil: shouldLock
+            ? new Date(now.getTime() + COOLDOWN_SECONDS * 1000)
+            : null,
+        },
+      });
+    }),
   },
 });

--- a/apps/api/src/shared/auth/auth.ts
+++ b/apps/api/src/shared/auth/auth.ts
@@ -26,18 +26,26 @@ function getTrustedOrigins() {
 // アカウントロック設定
 // - WINDOW_SECONDS 内に LOCK_THRESHOLD 回失敗したら COOLDOWN_SECONDS 間ロック
 // - WINDOW_SECONDS を超える間隔で散発的に失敗するケースは攻撃と見なさずカウンタをリセット
+// - account enumeration を避けるため、ロック中も外向きのレスポンスは通常の認証失敗と同一にする
 const LOCK_THRESHOLD = 5;
 const WINDOW_SECONDS = 3600;
 const COOLDOWN_SECONDS = 900;
 const SIGN_IN_PATH = "/sign-in/email";
-const ACCOUNT_LOCKED_CODE = "ACCOUNT_LOCKED";
-const ACCOUNT_LOCKED_MESSAGE =
-  "ログイン失敗が続いたためアカウントを一時的にロックしました。しばらくしてから再度お試しください。";
+// Better Auth が通常のパスワード不一致時に返すコード/メッセージと一致させる
+const INVALID_CREDENTIALS_CODE = "INVALID_EMAIL_OR_PASSWORD";
+const INVALID_CREDENTIALS_MESSAGE = "Invalid email or password";
 
 function getEmailFromBody(body: unknown): string | undefined {
   if (typeof body !== "object" || body === null) return undefined;
   const email = (body as { email?: unknown }).email;
   return typeof email === "string" ? email.toLowerCase() : undefined;
+}
+
+interface FailureRow {
+  id: string;
+  failed_login_attempts: number;
+  last_failed_login_at: Date | null;
+  locked_until: Date | null;
 }
 
 export const auth = betterAuth({
@@ -59,7 +67,6 @@ export const auth = betterAuth({
     disableOriginCheck: false,
   },
   hooks: {
-    // ロック中のユーザーは Better Auth のパスワード検証に到達する前にブロックする
     before: createAuthMiddleware(async (ctx) => {
       if (ctx.path !== SIGN_IN_PATH) return;
       const email = getEmailFromBody(ctx.body);
@@ -67,42 +74,49 @@ export const auth = betterAuth({
 
       const user = await prisma.user.findUnique({
         where: { email },
-        select: { lockedUntil: true },
+        select: { id: true, lockedUntil: true },
       });
       if (!user?.lockedUntil) return;
+
       if (user.lockedUntil.getTime() > Date.now()) {
-        throw new APIError("FORBIDDEN", {
-          message: ACCOUNT_LOCKED_MESSAGE,
-          code: ACCOUNT_LOCKED_CODE,
+        // ロック中。account enumeration を避けるため、未登録メールや
+        // パスワード不一致と外向きには区別がつかない 401 を返す
+        throw new APIError("UNAUTHORIZED", {
+          message: INVALID_CREDENTIALS_MESSAGE,
+          code: INVALID_CREDENTIALS_CODE,
         });
       }
+
+      // cooldown 経過。次の試行を「初回」として扱うためカウンタとロックを完全リセットしてから通す
+      await prisma.user.update({
+        where: { id: user.id },
+        data: {
+          failedLoginAttempts: 0,
+          lastFailedLoginAt: null,
+          lockedUntil: null,
+        },
+      });
     }),
-    // sign-in の結果に応じて失敗カウンタを更新する
     after: createAuthMiddleware(async (ctx) => {
       if (ctx.path !== SIGN_IN_PATH) return;
       const email = getEmailFromBody(ctx.body);
       if (!email) return;
 
-      const user = await prisma.user.findUnique({
-        where: { email },
-        select: {
-          id: true,
-          failedLoginAttempts: true,
-          lastFailedLoginAt: true,
-        },
-      });
-      // 存在しないユーザーは account enumeration を避けるため記録しない
-      if (!user) return;
-
       const returned = ctx.context.returned;
       const failed = returned instanceof APIError;
 
       if (!failed) {
-        if (user.failedLoginAttempts === 0 && user.lastFailedLoginAt === null) {
-          return;
-        }
-        await prisma.user.update({
-          where: { id: user.id },
+        // 成功。残っているカウンタとロックを atomic にリセット
+        // (updateMany + where 条件で no-op のときは書き込みしない)
+        await prisma.user.updateMany({
+          where: {
+            email,
+            OR: [
+              { failedLoginAttempts: { gt: 0 } },
+              { lastFailedLoginAt: { not: null } },
+              { lockedUntil: { not: null } },
+            ],
+          },
           data: {
             failedLoginAttempts: 0,
             lastFailedLoginAt: null,
@@ -112,26 +126,39 @@ export const auth = betterAuth({
         return;
       }
 
-      // ACCOUNT_LOCKED は before hook で出した自前エラー。二重カウントしない
-      if (returned.body?.code === ACCOUNT_LOCKED_CODE) return;
+      // 失敗時の更新は並行リクエストの increment が消えないように
+      // 行ロック (SELECT ... FOR UPDATE) で直列化する
+      await prisma.$transaction(async (tx) => {
+        const rows = await tx.$queryRaw<FailureRow[]>`
+          SELECT id, failed_login_attempts, last_failed_login_at, locked_until
+          FROM "user"
+          WHERE email = ${email}
+          FOR UPDATE
+        `;
+        const row = rows[0];
+        // 存在しないユーザーは account enumeration を避けるため記録しない
+        if (!row) return;
+        // 既にロック中のリクエストはカウントしない (DoS 抑制)
+        if (row.locked_until && row.locked_until.getTime() > Date.now()) return;
 
-      const now = new Date();
-      const withinWindow =
-        user.lastFailedLoginAt !== null &&
-        now.getTime() - user.lastFailedLoginAt.getTime() <
-          WINDOW_SECONDS * 1000;
-      const nextAttempts = withinWindow ? user.failedLoginAttempts + 1 : 1;
-      const shouldLock = nextAttempts >= LOCK_THRESHOLD;
+        const now = new Date();
+        const withinWindow =
+          row.last_failed_login_at !== null &&
+          now.getTime() - row.last_failed_login_at.getTime() <
+            WINDOW_SECONDS * 1000;
+        const nextAttempts = withinWindow ? row.failed_login_attempts + 1 : 1;
+        const shouldLock = nextAttempts >= LOCK_THRESHOLD;
 
-      await prisma.user.update({
-        where: { id: user.id },
-        data: {
-          failedLoginAttempts: nextAttempts,
-          lastFailedLoginAt: now,
-          lockedUntil: shouldLock
-            ? new Date(now.getTime() + COOLDOWN_SECONDS * 1000)
-            : null,
-        },
+        await tx.user.update({
+          where: { id: row.id },
+          data: {
+            failedLoginAttempts: nextAttempts,
+            lastFailedLoginAt: now,
+            lockedUntil: shouldLock
+              ? new Date(now.getTime() + COOLDOWN_SECONDS * 1000)
+              : null,
+          },
+        });
       });
     }),
   },

--- a/apps/api/src/shared/auth/auth.ts
+++ b/apps/api/src/shared/auth/auth.ts
@@ -103,9 +103,16 @@ export const auth = betterAuth({
       if (!email) return;
 
       const returned = ctx.context.returned;
-      const failed = returned instanceof APIError;
+      const isCredentialFailure =
+        returned instanceof APIError &&
+        returned.body?.code === INVALID_CREDENTIALS_CODE;
 
-      if (!failed) {
+      // 認証以外のエラー (Origin/CSRF: 403、rate limit: 429、バリデーション: 400 等) は
+      // 資格情報の真偽と無関係なので、ロックカウンタの加算もリセットも行わない。
+      // 攻撃者が CSRF 違反等を 5 回踏ませて被害者アカウントをロックさせる経路を塞ぐため。
+      if (returned instanceof APIError && !isCredentialFailure) return;
+
+      if (!isCredentialFailure) {
         // 成功。残っているカウンタとロックを atomic にリセット
         // (updateMany + where 条件で no-op のときは書き込みしない)
         await prisma.user.updateMany({
@@ -126,7 +133,7 @@ export const auth = betterAuth({
         return;
       }
 
-      // 失敗時の更新は並行リクエストの increment が消えないように
+      // 資格情報不一致時の更新は並行リクエストの increment が消えないように
       // 行ロック (SELECT ... FOR UPDATE) で直列化する
       await prisma.$transaction(async (tx) => {
         const rows = await tx.$queryRaw<FailureRow[]>`

--- a/apps/web/src/views/auth/ui/__tests__/auth-form.test.tsx
+++ b/apps/web/src/views/auth/ui/__tests__/auth-form.test.tsx
@@ -38,7 +38,7 @@ describe("AuthForm", () => {
 
     render(<AuthForm mode="login" />);
 
-    await user.type(screen.getByLabelText("パスワード"), "123456");
+    await user.type(screen.getByLabelText("パスワード"), "12345678");
     await user.click(screen.getByRole("button", { name: "ログイン" }));
 
     expect(
@@ -53,7 +53,7 @@ describe("AuthForm", () => {
     render(<AuthForm mode="login" />);
 
     await user.type(screen.getByLabelText("メールアドレス"), "invalid");
-    await user.type(screen.getByLabelText("パスワード"), "123456");
+    await user.type(screen.getByLabelText("パスワード"), "12345678");
     await user.click(screen.getByRole("button", { name: "ログイン" }));
 
     expect(
@@ -72,13 +72,13 @@ describe("AuthForm", () => {
       screen.getByLabelText("メールアドレス"),
       "mail@example.com",
     );
-    await user.type(screen.getByLabelText("パスワード"), "123456");
+    await user.type(screen.getByLabelText("パスワード"), "12345678");
     await user.click(screen.getByRole("button", { name: "ログイン" }));
 
     await waitFor(() =>
       expect(signInEmail).toHaveBeenCalledWith({
         email: "mail@example.com",
-        password: "123456",
+        password: "12345678",
       }),
     );
     expect(push).toHaveBeenCalledWith("/");
@@ -97,7 +97,7 @@ describe("AuthForm", () => {
       screen.getByLabelText("メールアドレス"),
       "mail@example.com",
     );
-    await user.type(screen.getByLabelText("パスワード"), "123456");
+    await user.type(screen.getByLabelText("パスワード"), "12345678");
     await user.click(screen.getByRole("button", { name: "アカウント作成" }));
 
     expect(await screen.findByText("Email rate limit exceeded")).toBeVisible();
@@ -135,13 +135,13 @@ describe("AuthForm", () => {
     render(<AuthForm mode="signup" />);
 
     await user.type(screen.getByLabelText("メールアドレス"), "new@example.com");
-    await user.type(screen.getByLabelText("パスワード"), "123456");
+    await user.type(screen.getByLabelText("パスワード"), "12345678");
     await user.click(screen.getByRole("button", { name: "アカウント作成" }));
 
     await waitFor(() =>
       expect(signUpEmail).toHaveBeenCalledWith({
         email: "new@example.com",
-        password: "123456",
+        password: "12345678",
         name: "new",
       }),
     );

--- a/apps/web/src/views/auth/ui/auth-form-schema.ts
+++ b/apps/web/src/views/auth/ui/auth-form-schema.ts
@@ -8,7 +8,7 @@ export const authFormSchema = z.object({
     .pipe(z.email({ error: "メールアドレスを正しく入力してください" })),
   password: z
     .string()
-    .min(6, "パスワードは6文字以上で入力してください")
+    .min(8, "パスワードは8文字以上で入力してください")
     .max(72, "パスワードは72文字以内で入力してください"),
 });
 

--- a/apps/web/src/views/auth/ui/auth-form.tsx
+++ b/apps/web/src/views/auth/ui/auth-form.tsx
@@ -85,7 +85,7 @@ export function AuthForm({ mode }: Props) {
               id="password"
               data-testid="auth-password-input"
               type="password"
-              placeholder="6文字以上"
+              placeholder="8文字以上"
               aria-invalid={!!errors.password}
               disabled={loading}
               {...register("password")}

--- a/apps/web/src/views/auth/ui/use-auth-form-submit.ts
+++ b/apps/web/src/views/auth/ui/use-auth-form-submit.ts
@@ -11,6 +11,8 @@ function toJapaneseMessage(code: string | undefined, fallback: string): string {
       return "メールアドレスまたはパスワードが正しくありません";
     case "USER_ALREADY_EXISTS":
       return "このメールアドレスは既に使用されています";
+    case "ACCOUNT_LOCKED":
+      return "ログイン失敗が続いたためアカウントを一時的にロックしました。しばらくしてから再度お試しください";
     case undefined:
     default:
       return fallback;

--- a/apps/web/src/views/auth/ui/use-auth-form-submit.ts
+++ b/apps/web/src/views/auth/ui/use-auth-form-submit.ts
@@ -11,8 +11,6 @@ function toJapaneseMessage(code: string | undefined, fallback: string): string {
       return "メールアドレスまたはパスワードが正しくありません";
     case "USER_ALREADY_EXISTS":
       return "このメールアドレスは既に使用されています";
-    case "ACCOUNT_LOCKED":
-      return "ログイン失敗が続いたためアカウントを一時的にロックしました。しばらくしてから再度お試しください";
     case undefined:
     default:
       return fallback;


### PR DESCRIPTION
## 概要

Better Auth に対して「ログイン失敗 5 回でアカウントを一時ロック」する hooks を追加する。account enumeration / cooldown 経過時のリセット / 並行 sign-in の race condition にも対処。

合わせて #86 のうちパスワード最低文字数を 6 → 8 に引き上げる（複雑性要件・漏洩辞書連携は #86 で別途検討）。

closes #78

## 変更内容

### アカウントロック (#78)

- `User` テーブルに `failedLoginAttempts` / `lastFailedLoginAt` / `lockedUntil` カラムを追加（migration 同梱）
- `apps/api/src/shared/auth/auth.ts` に Better Auth の `hooks.before` / `hooks.after` を追加
  - 失敗 5 回を 1 時間 window で集計、超えたら 15 分ロック
  - **enumeration 抑止**: ロック中も外向きには通常のパスワード不一致と同じ `401 INVALID_EMAIL_OR_PASSWORD` を返す（status / code / message が完全一致）
  - **cooldown 経過時の完全リセット**: `before` hook で `lockedUntil` 経過を検出したらカウンタも 0 にリセットしてから passthrough（1 ミスで再ロックされない）
  - **race condition 対策**: 失敗時の更新を `$transaction` + `SELECT ... FOR UPDATE` で直列化
  - 存在しないユーザーや既にロック中のリクエストは failure count を増やさない（DoS / enumeration 抑止）
- 攻撃シナリオテストを `auth-attack-vectors.test.ts` に追加
  - 失敗 5 回ロック / lockedUntil 記録 / cooldown 経過後の再ログイン
  - 直後の 1 ミスで再ロックされない / enumeration 同等性 / 並行 5 件の race / ロック中追加失敗で延長されない / 複数ユーザーのロック独立性

### パスワード最低文字数 6 → 8 (#86 の一部)

- `auth.ts` の `minPasswordLength: 8`
- Web 側 `auth-form-schema.ts` の `min(8, ...)` とエラーメッセージ
- `auth-form.tsx` の placeholder 文言更新
- 既存の境界値テストを 6 → 8 に修正

## 確認方法

- [x] `pnpm test` が通る (API 172 / Web 67)
- [x] `pnpm lint` が通る
- [x] `pnpm build` が通る
- [x] `pnpm test:e2e` が通る (7 passed)
- [ ] ブラウザで動作確認済み

## 関連

- #78 アカウントロック (closes)
- #86 パスワード強度の強化 (一部対応のみ。残りはコメント済み)
- #89 E2E (login.spec.ts) の初回実行で waitForURL が進まないケース (本 PR とは別途観測した事象)
- #90 Account Lockout DoS 対策 (本 PR の adversarial review で挙がった IP / device 単位 throttle の検討)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
