### PR TITLE
Web API クライアントの不要な型アサーションを整理

### DIFF
--- a/apps/web/src/shared/lib/api/index.ts
+++ b/apps/web/src/shared/lib/api/index.ts
@@ -1,9 +1,7 @@
 import { apiClient } from "./client";
 import { expectOk } from "./errors";
 import {
-  type CategoriesResponse,
   type CreateCategoryRequest,
-  type CreateCategorySuccess,
   type CreateTaskRequest,
   type CreateTaskSuccess,
   type CreateTimerSessionRequest,
@@ -14,19 +12,24 @@ import {
   normalizeTask,
   normalizeTimerSession,
   normalizeWorkRecord,
-  type TasksResponse,
-  type TimerSessionResponse,
   type UpdateCategoryRequest,
   type UpdateCategorySuccess,
   type UpdateTaskRequest,
   type UpdateTaskSuccess,
-  type WorkRecordsResponse,
 } from "./types";
+
+// 補足:
+// 単一ステータスのみを返すエンドポイント（GET 系や、エラー分岐を持たない一部の POST）
+// では、`response.json()` が成功 body の型に推論されるので型アサーションは不要。
+// 一方、`errorResponse` などで複数ステータスを返すエンドポイントは、Hono RPC の型が
+// 全レスポンス body を 1 つの ClientResponse にマージするため `response.json()` の
+// 推論結果が `成功 body | エラー body` の union になる。`response.ok` での narrowing は
+// 効かないので、成功 body のみを取り出すために `as ...Success` で型アサーションを残す。
 
 export async function fetchTasks() {
   const response = await apiClient.tasks.$get();
   await expectOk(response, "Failed to fetch tasks");
-  const tasks = (await response.json()) as TasksResponse;
+  const tasks = await response.json();
   return tasks.map(normalizeTask);
 }
 
@@ -55,14 +58,14 @@ export async function deleteTask(id: string) {
 export async function fetchCategories() {
   const response = await apiClient.categories.$get();
   await expectOk(response, "Failed to fetch categories");
-  const categories = (await response.json()) as CategoriesResponse;
+  const categories = await response.json();
   return categories.map(normalizeCategory);
 }
 
 export async function createCategory(input: CreateCategoryRequest) {
   const response = await apiClient.categories.$post({ json: input });
   await expectOk(response, "Failed to create category");
-  return normalizeCategory((await response.json()) as CreateCategorySuccess);
+  return normalizeCategory(await response.json());
 }
 
 export async function updateCategory(id: string, input: UpdateCategoryRequest) {
@@ -84,7 +87,7 @@ export async function deleteCategory(id: string) {
 export async function fetchWorkRecords() {
   const response = await apiClient["work-records"].$get();
   await expectOk(response, "Failed to fetch work records");
-  const records = (await response.json()) as WorkRecordsResponse;
+  const records = await response.json();
   return records.map(normalizeWorkRecord);
 }
 
@@ -99,7 +102,7 @@ export async function createWorkRecord(input: CreateWorkRecordRequest) {
 export async function fetchCurrentTimerSession() {
   const response = await apiClient["timer-sessions"].$get();
   await expectOk(response, "Failed to fetch timer session");
-  const session = (await response.json()) as TimerSessionResponse;
+  const session = await response.json();
   return session ? normalizeTimerSession(session) : null;
 }
 

--- a/apps/web/src/shared/lib/api/index.ts
+++ b/apps/web/src/shared/lib/api/index.ts
@@ -18,13 +18,17 @@ import {
   type UpdateTaskSuccess,
 } from "./types";
 
-// 補足:
-// 単一ステータスのみを返すエンドポイント（GET 系や、エラー分岐を持たない一部の POST）
-// では、`response.json()` が成功 body の型に推論されるので型アサーションは不要。
-// 一方、`errorResponse` などで複数ステータスを返すエンドポイントは、Hono RPC の型が
-// 全レスポンス body を 1 つの ClientResponse にマージするため `response.json()` の
-// 推論結果が `成功 body | エラー body` の union になる。`response.ok` での narrowing は
-// 効かないので、成功 body のみを取り出すために `as ...Success` で型アサーションを残す。
+// 補足: ここで言う「単一ステータス」とは、Hono RPC の型定義上 handler が
+// 成功 body のみを型付けしているエンドポイント（GET 系や、`errorResponse` で
+// 別 status を明示していない一部の POST）のこと。実行時には auth ミドルウェアや
+// validator で 401/400 が返り得るが、それらは型推論に反映されない。
+//
+// このケースでは `response.json()` が成功 body 型に推論されるので型アサーションは
+// 不要。一方、handler が `errorResponse` で複数 status を型付けしているエンド
+// ポイントは、Hono RPC が各レスポンス body を 1 つの ClientResponse にマージする
+// ため `response.json()` の推論結果が `成功 body | エラー body` の union になる。
+// `response.ok` での narrowing も効かないので、成功 body のみを取り出すために
+// `as ...Success` で型アサーションを残す。
 
 export async function fetchTasks() {
   const response = await apiClient.tasks.$get();

--- a/apps/web/src/shared/lib/api/server.ts
+++ b/apps/web/src/shared/lib/api/server.ts
@@ -31,9 +31,11 @@ const getServerApiClient = cache(async () => {
   return createApiClient(cookie ? { cookie } : {});
 });
 
-// この server 側の getter はいずれも単一ステータス（200）しか返さないエンドポイントを
-// 呼んでいるので、`response.json()` がそのまま成功 body 型に推論される。
-// よって `as ...Response` の型アサーションは不要。
+// ここで呼んでいる getter はいずれも、Hono RPC の型定義上は handler が単一の成功
+// レスポンス（200）のみを型付けしているエンドポイント。`response.json()` がその
+// まま成功 body 型に推論されるので `as ...Response` の型アサーションは不要。
+// （実行時には auth ミドルウェア等により 401 などが返り得るが、それは型推論には
+// 反映されないため別途 `expectOkOrRedirect` で扱う。）
 
 export const getTasks = cache(async () => {
   const client = await getServerApiClient();

--- a/apps/web/src/shared/lib/api/server.ts
+++ b/apps/web/src/shared/lib/api/server.ts
@@ -4,14 +4,10 @@ import { cache } from "react";
 import { createApiClient } from "./client";
 import { ApiError, expectOk } from "./errors";
 import {
-  type CategoriesResponse,
   normalizeCategory,
   normalizeTask,
   normalizeTimerSession,
   normalizeWorkRecord,
-  type TasksResponse,
-  type TimerSessionResponse,
-  type WorkRecordsResponse,
 } from "./types";
 
 function rethrowOrRedirectUnauthorized(error: unknown): never {
@@ -35,11 +31,15 @@ const getServerApiClient = cache(async () => {
   return createApiClient(cookie ? { cookie } : {});
 });
 
+// この server 側の getter はいずれも単一ステータス（200）しか返さないエンドポイントを
+// 呼んでいるので、`response.json()` がそのまま成功 body 型に推論される。
+// よって `as ...Response` の型アサーションは不要。
+
 export const getTasks = cache(async () => {
   const client = await getServerApiClient();
   const response = await client.tasks.$get();
   await expectOkOrRedirect(response, "Failed to fetch tasks");
-  const tasks = (await response.json()) as TasksResponse;
+  const tasks = await response.json();
   return tasks.map(normalizeTask);
 });
 
@@ -47,7 +47,7 @@ export const getCategories = cache(async () => {
   const client = await getServerApiClient();
   const response = await client.categories.$get();
   await expectOkOrRedirect(response, "Failed to fetch categories");
-  const categories = (await response.json()) as CategoriesResponse;
+  const categories = await response.json();
   return categories.map(normalizeCategory);
 });
 
@@ -55,7 +55,7 @@ export const getWorkRecords = cache(async () => {
   const client = await getServerApiClient();
   const response = await client["work-records"].$get();
   await expectOkOrRedirect(response, "Failed to fetch work records");
-  const records = (await response.json()) as WorkRecordsResponse;
+  const records = await response.json();
   return records.map(normalizeWorkRecord);
 });
 
@@ -63,6 +63,6 @@ export const getCurrentTimerSession = cache(async () => {
   const client = await getServerApiClient();
   const response = await client["timer-sessions"].$get();
   await expectOkOrRedirect(response, "Failed to fetch timer session");
-  const session = (await response.json()) as TimerSessionResponse;
+  const session = await response.json();
   return session ? normalizeTimerSession(session) : null;
 });


### PR DESCRIPTION
## 概要

Hono RPC の型推論を踏まえて、`apps/web` の API クライアントで使われていた `response.json()` 後の型アサーション（`as ...Response` / `as ...Success`）を整理した。

closes #72

## 変更内容

- 単一ステータスのみを返すエンドポイント（`tasks.$get` / `categories.$get` / `categories.$post` / `work-records.$get` / `timer-sessions.$get` 等）の `as` を削除
  - `response.json()` がそのまま成功 body 型に推論されるため不要
- 複数ステータスを返すエンドポイント（`tasks.$post` / `tasks.$put` / `categories.$put` / `work-records.$post` / `timer-sessions.$post`）の `as` は残し、なぜ必要なのかをファイル先頭にコメントで明記
  - Hono RPC の型は成功・エラー body を 1 つの ClientResponse にマージするため、`response.ok` での narrowing は効かず、成功 body のみを取り出す目的で型アサーションが必要

## 確認方法

- [x] `pnpm --filter @todo-list/web exec tsc --noEmit` が通る
- [x] `pnpm --filter @todo-list/web lint` が通る
- [x] `pnpm --filter @todo-list/web test` が通る
